### PR TITLE
Optimized Ravager pet

### DIFF
--- a/eco-core/core-plugin/src/main/resources/pets.yml
+++ b/eco-core/core-plugin/src/main/resources/pets.yml
@@ -297,28 +297,27 @@ pets:
         multiplier: 50
 
     level-placeholders:
-      - id: "health_boost"
-        value: "%level%"
+      - id: "health"
+        value: "%level%/2"
 
     effects-description:
       1:
-        - "&8» &8Gives a &a+%health_boost%%&8 bonus"
+        - "&8» &8Gives &c+%health%❤&8 bonus health"
 
     rewards-description:
       1:
-        - "&8» &8Gives a &a+%health_boost%%&8 bonus"
+        - "&8» &8Gives &c+%health%❤&8 bonus health"
 
     level-up-messages:
       1:
-        - "&8» &8Gives a &a+%health_boost%%&8 bonus"
+        - "&8» &8Gives &c+%health%❤&8 bonus health"
 
     level-commands: [ ]
 
     effects:
-      - id: potion_effect
+      - id: bonus_health
         args:
-          effect: health_boost
-          level: "%level%"
+          health: "%level%/2"
 
     conditions: [ ]
 


### PR DESCRIPTION
Also the current way of gaining xp for the ravager pet is kinda funky
You only gain xp when you have the hero of the village effect already active and gain another potion effect
I doubt its suppost to be like that but currently its not possible to give xp only when gaining the hero of the village effect
I suggest you add filtering to triggers so you can filter which potion effect