### PR TITLE
Fix Shopkeepers bug

### DIFF
--- a/eco-core/core-plugin/src/main/resources/plugin.yml
+++ b/eco-core/core-plugin/src/main/resources/plugin.yml
@@ -22,6 +22,9 @@ softdepend:
   - EcoSkills
   - Reforges
   - ModelEngine
+loadbefore:
+  - EcoEnchants
+
 commands:
   ecopets:
     description: Base Command


### PR DESCRIPTION
During initialization, Shopkeepers fails to recognize add-on enchantments from EcoEnchants and will replace any enchanted books with these add-on enchants as a blank enchanted book, this solves the issue.