### PR TITLE
Add ModelEngine animation option

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/entity/ModelEnginePetEntity.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/entity/ModelEnginePetEntity.kt
@@ -11,12 +11,20 @@ class ModelEnginePetEntity(
     private val modelID: String,
     private val plugin: EcoPetsPlugin
 ) : PetEntity(pet) {
+
+    val animation = pet.config.getStringOrNull("modelengine-animation")
+
     override fun spawn(location: Location): ArmorStand {
         val stand = emptyArmorStandAt(location, pet)
 
+        val modelled = ModelEngineBridge.instance.createModeledEntity(stand)
+
         val model = ModelEngineBridge.instance.createActiveModel(modelID) ?: return stand
 
-        val modelled = ModelEngineBridge.instance.createModeledEntity(stand)
+        if (animation != null) {
+            model.animationHandler.playAnimation(animation, 0.3, 0.3, 1.0, true)
+        }
+
         modelled.addModel(model)
 
         return stand


### PR DESCRIPTION
Added `modelengine-animation` option [specified on wiki](https://plugins.auxilor.io/ecopets/how-to-make-a-custom-pet#understanding-all-the-sections)

This pull request requires Auxilor/ModelEngineBridge#1 to be merged

### Information
For those people that probably experiment bugs using `idle`, `walk` or some other animation [supported by default on ModelEngine](https://git.lumine.io/mythiccraft/model-engine-4/-/wikis/Modeling/Animating-a-Model#default-states), DO NOT use those animation names for pets.
Pets are made with armor stands, and for some reason ModelEngine doesn't play default state animations on armor stands.

Also, the used animation should have a [loop](https://git.lumine.io/mythiccraft/model-engine-4/-/wikis/Modeling/Animating-a-Model#loop-mode).