### PR TITLE
ItemDisplay as pet entity

### DIFF
--- a/eco-core/core-plugin/build.gradle.kts
+++ b/eco-core/core-plugin/build.gradle.kts
@@ -2,7 +2,7 @@ group = "com.willfp"
 version = rootProject.version
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.19.3-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.20.4-R0.1-SNAPSHOT")
     compileOnly("com.github.ben-manes.caffeine:caffeine:3.0.2")
 
     implementation("com.willfp:ecomponent:1.3.0")

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pet.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pet.kt
@@ -238,7 +238,7 @@ class Pet(
     }
 
     fun makePetEntity(): PetEntity {
-        return PetEntity.create(this)
+        return PetEntity.create(plugin, this)
     }
 
     fun getLevel(level: Int): PetLevel = levels.get(level) {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pet.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pet.kt
@@ -145,7 +145,7 @@ class Pet(
                 NumberUtils.evaluateExpression(
                     sub.getString("value")
                         .replace("%level%", it.toString())
-                ).toNiceString()
+                )
             }
         }
 
@@ -407,7 +407,16 @@ class Pet(
         val commands = levelCommands[level] ?: emptyList()
 
         for (command in commands) {
-            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), command.replace("%player%", player.name))
+            var filledCommand = command.replace("%player%", player.name).replace("%level%", level.toString())
+
+            for (placeholder in levelPlaceholders) {
+                val value = placeholder(level)
+                filledCommand = filledCommand.replace("%${placeholder.id}%", value.toString())
+                filledCommand = filledCommand.replace("%${placeholder.id}_int%", value.toInt().toString())
+                filledCommand = filledCommand.replace("%${placeholder.id}_formatted%", value.toNiceString())
+            }
+
+            Bukkit.dispatchCommand(Bukkit.getConsoleSender(), filledCommand)
         }
     }
 
@@ -430,7 +439,7 @@ class Pet(
 
 private class LevelPlaceholder(
     val id: String,
-    private val function: (Int) -> String
+    private val function: (Int) -> Double
 ) {
     operator fun invoke(level: Int) = function(level)
 }
@@ -438,7 +447,7 @@ private class LevelPlaceholder(
 private fun Collection<LevelPlaceholder>.format(string: String, level: Int): String {
     var process = string
     for (placeholder in this) {
-        process = process.replace("%${placeholder.id}%", placeholder(level))
+        process = process.replace("%${placeholder.id}%", placeholder(level).toNiceString())
     }
     return process
 }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
@@ -29,7 +29,7 @@ class PetDisplay(
 
     fun tickAll() {
         for (player in Bukkit.getOnlinePlayers()) {
-            if (player.isOnline) {
+            if (player.isOnline && player.location.chunk.isLoaded && player.location.chunk.isEntitiesLoaded) {
                 tickPlayer(player)
             } else {
                 remove(player)

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
@@ -29,7 +29,11 @@ class PetDisplay(
 
     fun tickAll() {
         for (player in Bukkit.getOnlinePlayers()) {
-            tickPlayer(player)
+            if (player.isOnline) {
+                tickPlayer(player)
+            } else {
+                remove(player)
+            }
         }
 
         tick++
@@ -40,7 +44,7 @@ class PetDisplay(
         val pet = player.activePet
 
         if (pet != null) {
-            if (player.isInvisible || player.isDead) {
+            if (player.isInvisible || player.isDead || !player.isOnline) {
                 remove(player)
                 return
             }
@@ -153,7 +157,7 @@ class PetDisplay(
     @EventHandler
     fun onEntitiesUnload(event: EntitiesUnloadEvent) {
         trackedEntities.entries.forEach {
-            if(event.chunk == it.value.entity.chunk) {
+            if (event.chunk == it.value.entity.chunk) {
                 remove(it.key)
             }
         }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
@@ -82,10 +82,6 @@ class PetDisplay(
     }
 
     private fun getOrNew(player: Player): ArmorStand? {
-        if (player.isInvisible) {
-            return null
-        }
-
         val tracked = trackedEntities[player.uniqueId]
         val existing = tracked?.stand
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/entity/ItemDisplayPetEntity.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/entity/ItemDisplayPetEntity.kt
@@ -1,0 +1,30 @@
+package com.willfp.ecopets.pets.entity
+
+import com.willfp.eco.core.items.builder.SkullBuilder
+import com.willfp.ecopets.EcoPetsPlugin
+import com.willfp.ecopets.pets.Pet
+import org.bukkit.Location
+import org.bukkit.entity.Entity
+import org.bukkit.entity.ItemDisplay
+import org.bukkit.inventory.ItemStack
+
+class ItemDisplayPetEntity(
+    pet: Pet,
+    private val plugin: EcoPetsPlugin
+) : PetEntity(pet) {
+    override fun spawn(location: Location): Entity {
+        val skull: ItemStack = SkullBuilder()
+            .setSkullTexture(pet.entityTexture)
+            .build()
+
+        val itemDisplay = location.world!!.spawn(location, ItemDisplay::class.java) {
+            it.itemStack = skull
+            it.isCustomNameVisible = true
+            @Suppress("DEPRECATION")
+            it.customName = pet.name
+            it.teleportDuration = plugin.configYml.getInt("pet-entity.item-display.teleport-duration", 3)
+        }
+
+        return itemDisplay;
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/entity/ModelEnginePetEntity.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/entity/ModelEnginePetEntity.kt
@@ -4,14 +4,14 @@ import com.willfp.ecopets.EcoPetsPlugin
 import com.willfp.ecopets.pets.Pet
 import com.willfp.modelenginebridge.ModelEngineBridge
 import org.bukkit.Location
-import org.bukkit.entity.ArmorStand
+import org.bukkit.entity.Entity
 
 class ModelEnginePetEntity(
     pet: Pet,
     private val modelID: String,
     private val plugin: EcoPetsPlugin
 ) : PetEntity(pet) {
-    override fun spawn(location: Location): ArmorStand {
+    override fun spawn(location: Location): Entity {
         val stand = emptyArmorStandAt(location, pet)
 
         val model = ModelEngineBridge.instance.createActiveModel(modelID) ?: return stand

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/entity/PetEntity.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/entity/PetEntity.kt
@@ -1,15 +1,17 @@
 package com.willfp.ecopets.pets.entity
 
+import com.willfp.ecopets.EcoPetsPlugin
 import com.willfp.ecopets.pets.Pet
 import org.bukkit.Location
 import org.bukkit.entity.ArmorStand
+import org.bukkit.entity.Entity
 import org.bukkit.entity.EntityType
 import org.bukkit.inventory.EquipmentSlot
 
 abstract class PetEntity(
     val pet: Pet
 ) {
-    abstract fun spawn(location: Location): ArmorStand
+    abstract fun spawn(location: Location): Entity
 
     companion object {
         private val registrations = mutableMapOf<String, (Pet, String) -> PetEntity>()
@@ -20,10 +22,13 @@ abstract class PetEntity(
         }
 
         @JvmStatic
-        fun create(pet: Pet): PetEntity {
+        fun create(plugin: EcoPetsPlugin, pet: Pet): PetEntity {
             val texture = pet.entityTexture
 
             if (!texture.contains(":")) {
+                if (plugin.configYml.getBool("pet-entity.item-display.enabled")) {
+                    return ItemDisplayPetEntity(pet, plugin)
+                }
                 return SkullPetEntity(pet)
             }
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/entity/SkullPetEntity.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/entity/SkullPetEntity.kt
@@ -3,11 +3,11 @@ package com.willfp.ecopets.pets.entity
 import com.willfp.eco.core.items.builder.SkullBuilder
 import com.willfp.ecopets.pets.Pet
 import org.bukkit.Location
-import org.bukkit.entity.ArmorStand
+import org.bukkit.entity.Entity
 import org.bukkit.inventory.ItemStack
 
 class SkullPetEntity(pet: Pet) : PetEntity(pet) {
-    override fun spawn(location: Location): ArmorStand {
+    override fun spawn(location: Location): Entity {
         val stand = emptyArmorStandAt(location, pet)
 
         val skull: ItemStack = SkullBuilder()

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -261,6 +261,10 @@ level-gui:
 pet-entity:
   enabled: true # If you disable this, there will be no floating pets
   name: "%player%&f's %pet%&f (Lvl. %level%)"
+  item-display:
+    enabled: false
+    teleport-duration: 3
+
 
 level-up:
   message:


### PR DESCRIPTION
Lets try this again. 
The main thing the PR does is adding ItemDisplay as a valid pet entity option. (It does not have a hitbox and it is smoother than armor stands)

Addition bug fixes:
- fixes invis potion bug
- fixes a lot of leftover entities on player death, chunk unloads and on instant player join/quit

1 additional feature I can't live without:
- Fill those placeholders in the level up commands.

The checks in the EntitiesUnloadEvent might not be needed, but I'm not sure since these are fixing dumb edge cases. As a server owner, it is annoying to kill these entities by hand.