### PR TITLE
Added pet visibility setting for players

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pet.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pet.kt
@@ -449,6 +449,12 @@ private val activePetKey: PersistentDataKey<String> = PersistentDataKey(
     ""
 )
 
+private val shouldHidePetKey: PersistentDataKey<Boolean> = PersistentDataKey(
+    EcoPetsPlugin.instance.namespacedKeyFactory.create("hide_pet"),
+    PersistentDataKeyType.BOOLEAN,
+    false
+)
+
 private val petEggKey = EcoPetsPlugin.instance.namespacedKeyFactory.create("pet_egg")
 
 var ItemStack.petEgg: Pet?
@@ -467,6 +473,10 @@ val OfflinePlayer.activePetLevel: PetLevel?
         val active = this.activePet ?: return null
         return this.getPetLevelObject(active)
     }
+
+var OfflinePlayer.shouldHidePet: Boolean
+    get() = this.profile.read(shouldHidePetKey)
+    set(value) = this.profile.write(shouldHidePetKey, value)
 
 fun OfflinePlayer.getPetLevel(pet: Pet): Int =
     this.profile.read(pet.levelKey)

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
@@ -12,7 +12,7 @@ import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerChangedWorldEvent
 import org.bukkit.event.player.PlayerQuitEvent
 import org.bukkit.event.player.PlayerTeleportEvent
-import java.util.UUID
+import java.util.*
 import kotlin.math.PI
 import kotlin.math.abs
 
@@ -32,6 +32,11 @@ class PetDisplay(
     }
 
     private fun tickPlayer(player: Player) {
+        if (player.shouldHidePet) {
+            remove(player)
+            return
+        }
+
         val stand = getOrNew(player) ?: return
         val pet = player.activePet
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetsGUI.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetsGUI.kt
@@ -53,6 +53,22 @@ object PetsGUI {
                     .build()
         }
 
+        val togglePetItemBuilder = { player: Player, _: Menu ->
+            val isPetVisible = !player.shouldHidePet
+
+            if (isPetVisible) {
+                ItemStackBuilder(Items.lookup(plugin.configYml.getString("gui.toggle.hide-pet.item")))
+                    .setDisplayName(plugin.configYml.getFormattedString("gui.toggle.hide-pet.name"))
+                    .addLoreLines(plugin.configYml.getFormattedStrings("gui.toggle.hide-pet.lore"))
+                    .build()
+            } else {
+                ItemStackBuilder(Items.lookup(plugin.configYml.getString("gui.toggle.show-pet.item")))
+                    .setDisplayName(plugin.configYml.getFormattedString("gui.toggle.show-pet.name"))
+                    .addLoreLines(plugin.configYml.getFormattedStrings("gui.toggle.show-pet.lore"))
+                    .build()
+            }
+        }
+
         val petIconBuilder = { player: Player, menu: Menu, index: Int ->
             val page = menu.getPage(player)
 
@@ -199,6 +215,16 @@ object PetsGUI {
                     onLeftClick { event, _ ->
                         val player = event.whoClicked as Player
                         player.activePet = null
+                    }
+                }
+            )
+
+            setSlot(plugin.configYml.getInt("gui.toggle.location.row"),
+                plugin.configYml.getInt("gui.toggle.location.column"),
+                slot(togglePetItemBuilder) {
+                    onLeftClick { event, _ ->
+                        val player = event.whoClicked as Player
+                        player.shouldHidePet = !player.shouldHidePet
                     }
                 }
             )

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -147,6 +147,23 @@ gui:
       row: 6
       column: 2
 
+  toggle:
+    hide-pet:
+      item: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTI1YjhlZWQ1YzU2NWJkNDQwZWM0N2M3OWMyMGQ1Y2YzNzAxNjJiMWQ5YjVkZDMxMDBlZDYyODNmZTAxZDZlIn19fQ==
+      name: "&cHide Pet"
+      lore:
+        - "&f"
+        - "&eClick to hide your pet"
+    show-pet:
+      item: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjNmNzliMjA3ZDYxZTEyMjUyM2I4M2Q2MTUwOGQ5OWNmYTA3OWQ0NWJmMjNkZjJhOWE1MTI3ZjkwNzFkNGIwMCJ9fX0=
+      name: "&aShow Pet"
+      lore:
+        - "&f"
+        - "&eClick to show your pet"
+    location:
+      row: 6
+      column: 8
+
   # Custom GUI slots; see here for a how-to: https://plugins.auxilor.io/all-plugins/custom-gui-slots
   custom-slots: [ ]
 

--- a/eco-core/core-plugin/src/main/resources/lang.yml
+++ b/eco-core/core-plugin/src/main/resources/lang.yml
@@ -24,6 +24,7 @@ messages:
   no-pet-active: "&cYou don't have a pet active!"
   activated-pet: "&fYou have activated the %pet%&f pet!"
   deactivated-pet: "&fYou have deactivated the %pet%&f pet!"
+  toggled-pet: "&fYour pet is now %status%!"
 
 menu:
   title: "Pets"


### PR DESCRIPTION
This PR adds an icon in the gui for pets which allows players to toggle the visibility of their pets to other players. This is useful for servers that have other flying cosmetics. The buffs of the pet are still active, just the model is not present. 