### PR TITLE
Modernizes XP Requirements and Level Effects

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ allprojects {
     }
 
     dependencies {
-        compileOnly("com.willfp:eco:6.55.0")
+        compileOnly("com.willfp:eco:6.56.0")
         compileOnly("org.jetbrains:annotations:23.0.0")
         compileOnly("org.jetbrains.kotlin:kotlin-stdlib:2.1.0")
     }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/api/EcoPetsAPI.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/api/EcoPetsAPI.kt
@@ -102,7 +102,7 @@ interface EcoPetsAPI {
     fun getPetXPRequired(
         player: OfflinePlayer,
         pet: Pet
-    ): Int
+    ): Double
 
     /**
      * Get experience to the next level.

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pet.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pet.kt
@@ -58,9 +58,7 @@ class Pet(
     )
 
     val xpKey: PersistentDataKey<Double> = PersistentDataKey(
-        EcoPetsPlugin.instance.namespacedKeyFactory.create("${id}_xp"),
-        PersistentDataKeyType.DOUBLE,
-        0.0
+        EcoPetsPlugin.instance.namespacedKeyFactory.create("${id}_xp"), PersistentDataKeyType.DOUBLE, 0.0
     )
 
     private val spawnEggBacker: ItemStack? = run {
@@ -135,17 +133,13 @@ class Pet(
 
     private val conditions: ConditionList
 
-    private val levels = Caffeine.newBuilder()
-        .build<Int, PetLevel>()
+    private val levels = Caffeine.newBuilder().build<Int, PetLevel>()
 
-    private val effectsDescription = Caffeine.newBuilder()
-        .build<Int, List<String>>()
+    private val effectsDescription = Caffeine.newBuilder().build<Int, List<String>>()
 
-    private val rewardsDescription = Caffeine.newBuilder()
-        .build<Int, List<String>>()
+    private val rewardsDescription = Caffeine.newBuilder().build<Int, List<String>>()
 
-    private val levelUpMessages = Caffeine.newBuilder()
-        .build<Int, List<String>>()
+    private val levelUpMessages = Caffeine.newBuilder().build<Int, List<String>>()
 
     private val levelCommands = mutableMapOf<Int, MutableList<String>>()
 
@@ -162,10 +156,7 @@ class Pet(
         }
 
     private val petXpGains = config.getSubsections("xp-gain-methods").mapNotNull {
-        Counters.compile(
-            it,
-            ViolationContext(plugin, "Pet $id XP Gain methods")
-        )
+        Counters.compile(it, ViolationContext(plugin, "Pet $id"))
     }
 
     init {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pet.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pet.kt
@@ -16,25 +16,29 @@ import com.willfp.eco.core.recipe.Recipes
 import com.willfp.eco.core.recipe.parts.EmptyTestableItem
 import com.willfp.eco.core.registry.Registrable
 import com.willfp.eco.util.NumberUtils
+import com.willfp.eco.util.NumberUtils.evaluateExpression
+import com.willfp.eco.core.placeholder.context.placeholderContext
 import com.willfp.eco.util.formatEco
 import com.willfp.eco.util.toNiceString
 import com.willfp.ecopets.EcoPetsPlugin
 import com.willfp.ecopets.api.event.PlayerPetExpGainEvent
 import com.willfp.ecopets.api.event.PlayerPetLevelUpEvent
 import com.willfp.ecopets.pets.entity.PetEntity
+import com.willfp.ecopets.util.LevelInjectable
 import com.willfp.libreforge.ViolationContext
 import com.willfp.libreforge.conditions.ConditionList
 import com.willfp.libreforge.conditions.Conditions
 import com.willfp.libreforge.counters.Counters
 import com.willfp.libreforge.effects.EffectList
 import com.willfp.libreforge.effects.Effects
+import com.willfp.libreforge.effects.executors.impl.NormalExecutorFactory
 import org.bukkit.Bukkit
 import org.bukkit.OfflinePlayer
+import org.bukkit.configuration.InvalidConfigurationException
 import org.bukkit.entity.Player
 import org.bukkit.inventory.ItemStack
 import org.bukkit.persistence.PersistentDataType
 import java.util.Objects
-import java.util.concurrent.TimeUnit
 import kotlin.math.abs
 
 class Pet(
@@ -42,7 +46,9 @@ class Pet(
     val config: Config,
     private val plugin: EcoPetsPlugin
 ) : Registrable {
+
     val name = config.getFormattedString("name")
+
     val description = config.getFormattedString("description")
 
     val levelKey: PersistentDataKey<Int> = PersistentDataKey(
@@ -115,23 +121,29 @@ class Pet(
 
     val entityTexture = config.getString("entity-texture")
 
-    private val levelXpRequirements = listOf(0) + config.getInts("level-xp-requirements")
+    private val xpFormula = config.getStringOrNull("xp-formula")
 
-    val maxLevel = levelXpRequirements.size
+    private val levelXpRequirements = config.getDoublesOrNull("level-xp-requirements")
+
+    val maxLevel = config.getIntOrNull("max-level") ?: levelXpRequirements?.size ?: Int.MAX_VALUE
 
     val levelGUI = PetLevelGUI(plugin, this)
 
     private val baseItem: ItemStack = Items.lookup(config.getString("icon")).item
 
     private val effects: EffectList
+
     private val conditions: ConditionList
 
     private val levels = Caffeine.newBuilder()
         .build<Int, PetLevel>()
+
     private val effectsDescription = Caffeine.newBuilder()
         .build<Int, List<String>>()
+
     private val rewardsDescription = Caffeine.newBuilder()
         .build<Int, List<String>>()
+
     private val levelUpMessages = Caffeine.newBuilder()
         .build<Int, List<String>>()
 
@@ -157,6 +169,10 @@ class Pet(
     }
 
     init {
+        if (xpFormula == null && levelXpRequirements == null) {
+            throw InvalidConfigurationException("Pet $id has no requirements or xp formula")
+        }
+
         config.injectPlaceholders(
             PlayerStaticPlaceholder(
                 "level"
@@ -175,24 +191,7 @@ class Pet(
             ViolationContext(plugin, "Pet $id")
         )
 
-        for (string in config.getStrings("level-commands")) {
-            val split = string.split(":")
-
-            if (split.size == 1) {
-                for (level in 1..maxLevel) {
-                    val commands = levelCommands[level] ?: mutableListOf()
-                    commands.add(string)
-                    levelCommands[level] = commands
-                }
-            } else {
-                val level = split[0].toInt()
-
-                val command = string.removePrefix("$level:")
-                val commands = levelCommands[level] ?: mutableListOf()
-                commands.add(command)
-                levelCommands[level] = commands
-            }
-        }
+        manageLevelCommands(config)
 
         PlayerPlaceholder(
             plugin,
@@ -236,6 +235,37 @@ class Pet(
             it.getPetLevel(this).toString()
         }.register()
     }
+
+    @Deprecated("Use level-up-effects instead")
+    private fun manageLevelCommands(config: Config) {
+        if (config.getStrings("level-commands").isNotEmpty()) {
+            plugin.logger.warning("$id pet: The `level-commands` key is deprecated and will be removed in future versions. Switch to `level-up-effects` instead. Refer to the wiki for more info.")
+        }
+        for (string in config.getStrings("level-commands")) {
+            val split = string.split(":")
+
+            if (split.size == 1) {
+                for (level in 1..maxLevel) {
+                    val commands = levelCommands[level] ?: mutableListOf()
+                    commands.add(string)
+                    levelCommands[level] = commands
+                }
+            } else {
+                val level = split[0].toInt()
+
+                val command = string.removePrefix("$level:")
+                val commands = levelCommands[level] ?: mutableListOf()
+                commands.add(command)
+                levelCommands[level] = commands
+            }
+        }
+    }
+
+    val levelUpEffects = Effects.compileChain(
+        config.getSubsections("level-up-effects"),
+        NormalExecutorFactory.create(),
+        ViolationContext(plugin, "Job $id level-up-effects")
+    )
 
     fun makePetEntity(): PetEntity {
         return PetEntity.create(this)
@@ -313,14 +343,7 @@ class Pet(
             .map {
                 it.replace("%percentage_progress%", (player.getPetProgress(this) * 100).toNiceString())
                     .replace("%current_xp%", player.getPetXP(this).toNiceString())
-                    .replace("%required_xp%", this.getExpForLevel(player.getPetLevel(this) + 1).let { req ->
-                        if (req == Int.MAX_VALUE) {
-                            plugin.langYml.getFormattedString("infinity")
-                        } else {
-                            req.toNiceString()
-                        }
-                    }
-                    )
+                    .replace("required_xp", this.getFormattedExpForLevel(player.getPetLevel(this) + 1))
                     .replace("%description%", this.description)
                     .replace("%pet%", this.name)
                     .replace("%level%", (forceLevel ?: player.getPetLevel(this)).toString())
@@ -395,14 +418,36 @@ class Pet(
             .build()
     }
 
-    fun getExpForLevel(level: Int): Int {
-        if (level < 1 || level > maxLevel) {
-            return Int.MAX_VALUE
+    /**
+     * Get the XP required to reach the next level, if currently at [level].
+     */
+    fun getExpForLevel(level: Int): Double {
+        if (xpFormula != null) {
+            return evaluateExpression(
+                xpFormula,
+                placeholderContext(
+                    injectable = LevelInjectable(level)
+                )
+            )
         }
 
-        return levelXpRequirements[level - 1]
+        if (levelXpRequirements != null) {
+            return levelXpRequirements.getOrNull(level) ?: Double.POSITIVE_INFINITY
+        }
+
+        return Double.POSITIVE_INFINITY
     }
 
+    fun getFormattedExpForLevel(level: Int): String {
+        val required = getExpForLevel(level)
+        return if (required.isInfinite()) {
+            plugin.langYml.getFormattedString("infinity")
+        } else {
+            required.toNiceString()
+        }
+    }
+
+    @Deprecated("Use level-up-effects instead")
     fun executeLevelCommands(player: Player, level: Int) {
         val commands = levelCommands[level] ?: emptyList()
 
@@ -492,45 +537,8 @@ fun OfflinePlayer.getPetXP(pet: Pet): Double =
 fun OfflinePlayer.setPetXP(pet: Pet, xp: Double) =
     this.profile.write(pet.xpKey, xp)
 
-fun OfflinePlayer.getPetXPRequired(pet: Pet): Int =
-    pet.getExpForLevel(this.getPetLevel(pet) + 1)
-
-private val expMultiplierCache = Caffeine.newBuilder()
-    .expireAfterWrite(10, TimeUnit.SECONDS)
-    .build<Player, Double> {
-        it.cacheSkillExperienceMultiplier()
-    }
-
-val Player.petExperienceMultiplier: Double
-    get() = expMultiplierCache.get(this)!!
-
-private fun Player.cacheSkillExperienceMultiplier(): Double {
-    if (this.hasPermission("ecopets.xpmultiplier.quadruple")) {
-        return 4.0
-    }
-
-    if (this.hasPermission("ecopets.xpmultiplier.triple")) {
-        return 3.0
-    }
-
-    if (this.hasPermission("ecopets.xpmultiplier.double")) {
-        return 2.0
-    }
-
-    if (this.hasPermission("ecopets.xpmultiplier.50percent")) {
-        return 1.5
-    }
-
-    val prefix = "ecopets.xpmultiplier."
-    for (permissionAttachmentInfo in this.effectivePermissions) {
-        val permission = permissionAttachmentInfo.permission
-        if (permission.startsWith(prefix)) {
-            return ((permission.substring(permission.lastIndexOf(".") + 1).toDoubleOrNull() ?: 100.0) / 100) + 1
-        }
-    }
-
-    return 1.0
-}
+fun OfflinePlayer.getPetXPRequired(pet: Pet) =
+    this.profile.read(pet.xpKey)
 
 fun Player.givePetExperience(pet: Pet, experience: Double, noMultiply: Boolean = false) {
     val exp = abs(if (noMultiply) experience else experience * this.petExperienceMultiplier)

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pet.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pet.kt
@@ -334,7 +334,7 @@ class Pet(
             .map {
                 it.replace("%percentage_progress%", (player.getPetProgress(this) * 100).toNiceString())
                     .replace("%current_xp%", player.getPetXP(this).toNiceString())
-                    .replace("required_xp", this.getFormattedExpForLevel(player.getPetLevel(this) + 1))
+                    .replace("%required_xp%", this.getFormattedExpForLevel(player.getPetLevel(this) + 1))
                     .replace("%description%", this.description)
                     .replace("%pet%", this.name)
                     .replace("%level%", (forceLevel ?: player.getPetLevel(this)).toString())

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetLevelListener.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetLevelListener.kt
@@ -2,6 +2,7 @@ package com.willfp.ecopets.pets
 
 import com.willfp.ecopets.EcoPetsPlugin
 import com.willfp.ecopets.api.event.PlayerPetLevelUpEvent
+import com.willfp.libreforge.toDispatcher
 import org.bukkit.Sound
 import org.bukkit.event.EventHandler
 import org.bukkit.event.EventPriority
@@ -16,6 +17,7 @@ class PetLevelListener(
         val player = event.player
         val level = event.level
 
+        pet.levelUpEffects?.trigger(player.toDispatcher())
         pet.executeLevelCommands(player, level)
 
         if (this.plugin.configYml.getBool("level-up.sound.enabled")) {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetXPAccumulator.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetXPAccumulator.kt
@@ -1,7 +1,9 @@
 package com.willfp.ecopets.pets
 
+import com.github.benmanes.caffeine.cache.Caffeine
 import com.willfp.libreforge.counters.Accumulator
 import org.bukkit.entity.Player
+import java.util.concurrent.TimeUnit
 
 class PetXPAccumulator(
     private val pet: Pet
@@ -13,4 +15,41 @@ class PetXPAccumulator(
 
         player.givePetExperience(pet, count)
     }
+}
+
+private val expMultiplierCache = Caffeine.newBuilder()
+    .expireAfterWrite(10, TimeUnit.SECONDS)
+    .build<Player, Double> {
+        it.cachePetExperienceMultiplier()
+    }
+
+val Player.petExperienceMultiplier: Double
+    get() = expMultiplierCache.get(this)!!
+
+private fun Player.cachePetExperienceMultiplier(): Double {
+    if (this.hasPermission("ecopets.xpmultiplier.quadruple")) {
+        return 4.0
+    }
+
+    if (this.hasPermission("ecopets.xpmultiplier.triple")) {
+        return 3.0
+    }
+
+    if (this.hasPermission("ecopets.xpmultiplier.double")) {
+        return 2.0
+    }
+
+    if (this.hasPermission("ecopets.xpmultiplier.50percent")) {
+        return 1.5
+    }
+
+    val prefix = "ecopets.xpmultiplier."
+    for (permissionAttachmentInfo in this.effectivePermissions) {
+        val permission = permissionAttachmentInfo.permission
+        if (permission.startsWith(prefix)) {
+            return ((permission.substring(permission.lastIndexOf(".") + 1).toDoubleOrNull() ?: 100.0) / 100) + 1
+        }
+    }
+
+    return 1.0
 }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/util/LevelInjectable.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/util/LevelInjectable.kt
@@ -1,0 +1,27 @@
+package com.willfp.ecopets.util
+
+import com.willfp.eco.core.placeholder.InjectablePlaceholder
+import com.willfp.eco.core.placeholder.PlaceholderInjectable
+import com.willfp.eco.core.placeholder.StaticPlaceholder
+
+class LevelInjectable(
+    level: Int
+) : PlaceholderInjectable {
+    private val placeholders = listOf(
+        StaticPlaceholder(
+            "level"
+        ) { level.toString() }
+    )
+
+    override fun getPlaceholderInjections(): List<InjectablePlaceholder> {
+        return placeholders
+    }
+
+    override fun addInjectablePlaceholder(p0: Iterable<InjectablePlaceholder>) {
+        return
+    }
+
+    override fun clearInjectedPlaceholders() {
+        return
+    }
+}

--- a/eco-core/core-plugin/src/main/resources/pets/_example.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/_example.yml
@@ -11,6 +11,15 @@ name: "&6Tiger"
 description: "&8&oLevel up by dealing melee damage"
 
 # The xp requirements for each pet level - add new levels by adding more to this list
+# There are two ways to specify level XP requirements:
+#  1. A formula to calculate for infinite levels
+#  2. A list of XP requirements for each level
+
+# Formula
+# xp-formula: (2 ^ %level%) * 25
+# max-level: 100 # The max level of the pet
+
+# List
 level-xp-requirements:
   - 50
   - 125
@@ -97,10 +106,13 @@ level-up-messages:
     - "&8» &8Gives a &a+%damage_multiplier%%&8 bonus to"
     - "   &8melee damage"
 
-# Commands to be sent on levelup, can be formatted two ways:
-# level:command (e.g. 10:eco give %player% 1000), which would execute that command for level 10
-# command (e.g. eco give %player% 5000), which would execute that command for all levels
-level-commands: [ ]
+# Effects to run when the pet levels up
+# %level% is the level the pet leveled up to.
+# If you want to restrict this to certain levels, you can use
+# require: %level% = 20, or require: %level% < 50, etc.
+# If you want a reward to run every x levels, you can use
+# every: 1, or every: 12, etc
+level-up-effects: [ ]
 
 # The effects for the pet, has %level% as a placeholder
 effects:

--- a/eco-core/core-plugin/src/main/resources/pets/blaze.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/blaze.yml
@@ -54,7 +54,7 @@ level-xp-requirements:
   - 3100000
   - 3400000
   - 3700000
-  -
+
 xp-gain-methods:
   - id: kill
     multiplier: 1

--- a/eco-core/core-plugin/src/main/resources/pets/blaze.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/blaze.yml
@@ -4,18 +4,6 @@ description: "&7Earn more XP from killing mobs"
 entity-texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjIwNjU3ZTI0YjU2ZTFiMmY4ZmMyMTlkYTFkZTc4OGMwYzI0ZjM2Mzg4YjFhNDA5ZDBjZDJkOGRiYTQ0YWEzYiJ9fX0="
 icon: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjIwNjU3ZTI0YjU2ZTFiMmY4ZmMyMTlkYTFkZTc4OGMwYzI0ZjM2Mzg4YjFhNDA5ZDBjZDJkOGRiYTQ0YWEzYiJ9fX0=
 
-spawn-egg:
-  enabled: true # If the pet should have a spawn egg
-  item: blaze_spawn_egg unbreaking:1 hide_enchants
-  name: "&#FF6600Blaze &fSpawn Egg"
-  lore:
-    - ""
-    - "&8&oPlace on the ground to"
-    - "&8&ounlock the &#FF6600Blaze pet!"
-  craftable: false
-  recipe: []
-  recipe-permission: ecopets.craft.blaze
-
 level-xp-requirements:
   - 50
   - 125
@@ -91,3 +79,15 @@ effects:
       multiplier: "%level% * 0.02 + 1"
 
 conditions: [ ]
+
+spawn-egg:
+  enabled: true # If the pet should have a spawn egg
+  item: blaze_spawn_egg unbreaking:1 hide_enchants
+  name: "&#FF6600Blaze &fSpawn Egg"
+  lore:
+    - ""
+    - "&8&oPlace on the ground to"
+    - "&8&ounlock the &#FF6600Blaze pet!"
+  craftable: false
+  recipe: []
+  recipe-permission: ecopets.craft.blaze

--- a/eco-core/core-plugin/src/main/resources/pets/blaze.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/blaze.yml
@@ -1,5 +1,21 @@
 name: "&#FF6600Blaze"
 description: "&7Earn more XP from killing mobs"
+
+entity-texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjIwNjU3ZTI0YjU2ZTFiMmY4ZmMyMTlkYTFkZTc4OGMwYzI0ZjM2Mzg4YjFhNDA5ZDBjZDJkOGRiYTQ0YWEzYiJ9fX0="
+icon: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjIwNjU3ZTI0YjU2ZTFiMmY4ZmMyMTlkYTFkZTc4OGMwYzI0ZjM2Mzg4YjFhNDA5ZDBjZDJkOGRiYTQ0YWEzYiJ9fX0=
+
+spawn-egg:
+  enabled: true # If the pet should have a spawn egg
+  item: blaze_spawn_egg unbreaking:1 hide_enchants
+  name: "&#FF6600Blaze &fSpawn Egg"
+  lore:
+    - ""
+    - "&8&oPlace on the ground to"
+    - "&8&ounlock the &#FF6600Blaze pet!"
+  craftable: false
+  recipe: []
+  recipe-permission: ecopets.craft.blaze
+
 level-xp-requirements:
   - 50
   - 125
@@ -50,32 +66,28 @@ level-xp-requirements:
   - 3100000
   - 3400000
   - 3700000
+  -
 xp-gain-methods:
   - id: kill
     multiplier: 1
+
 level-placeholders:
   - id: "xp_multiplier"
     value: "%level% * 2"
+
 effects-description:
   1:
     - "&6Â» &7Increased XP gain by %xp_multiplier%%!"
+    -
 rewards-description: []
+
 level-up-messages: []
-level-commands: []
+
+level-up-effects: []
+
 effects:
   - id: xp_multiplier
     args:
       multiplier: "%level% * 0.02 + 1"
-entity-texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjIwNjU3ZTI0YjU2ZTFiMmY4ZmMyMTlkYTFkZTc4OGMwYzI0ZjM2Mzg4YjFhNDA5ZDBjZDJkOGRiYTQ0YWEzYiJ9fX0="
-icon: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjIwNjU3ZTI0YjU2ZTFiMmY4ZmMyMTlkYTFkZTc4OGMwYzI0ZjM2Mzg4YjFhNDA5ZDBjZDJkOGRiYTQ0YWEzYiJ9fX0=
-spawn-egg:
-  enabled: true # If the pet should have a spawn egg
-  item: blaze_spawn_egg unbreaking:1 hide_enchants
-  name: "&#FF6600Blaze &fSpawn Egg"
-  lore:
-    - ""
-    - "&8&oPlace on the ground to"
-    - "&8&ounlock the &#FF6600Blaze pet!"
-  craftable: false
-  recipe: []
-  recipe-permission: ecopets.craft.blaze
+
+conditions: [ ]

--- a/eco-core/core-plugin/src/main/resources/pets/mancubus.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/mancubus.yml
@@ -1,6 +1,21 @@
 name: "&6Mancubus"
 description: "&8&oLevel up by taking damage while on fire"
 
+entity-texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTA5NWZjYzFlM2Q3Y2JkMzUwZjE5YjM4OTQ5OGFiOGJiOTZjNjVhZDE4NWQzNDU5MjA2N2E3ZDAzM2FjNDhkZSJ9fX0="
+icon: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTA5NWZjYzFlM2Q3Y2JkMzUwZjE5YjM4OTQ5OGFiOGJiOTZjNjVhZDE4NWQzNDU5MjA2N2E3ZDAzM2FjNDhkZSJ9fX0=
+
+spawn-egg:
+  enabled: true # If the pet should have a spawn egg
+  item: magma_cube_spawn_egg unbreaking:1 hide_enchants
+  name: "&6Mancubus&f Spawn Egg"
+  lore:
+    - ""
+    - "&8&oPlace on the ground to"
+    - "&8&ounlock the &r&6Mancubus&8&o pet!"
+  craftable: false
+  recipe: [ ]
+  recipe-permission: ecopets.craft.mancubus
+
 level-xp-requirements:
   - 50
   - 125
@@ -86,19 +101,3 @@ effects:
       - melee_attack
 
 conditions: [ ]
-
-entity-texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTA5NWZjYzFlM2Q3Y2JkMzUwZjE5YjM4OTQ5OGFiOGJiOTZjNjVhZDE4NWQzNDU5MjA2N2E3ZDAzM2FjNDhkZSJ9fX0="
-
-icon: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTA5NWZjYzFlM2Q3Y2JkMzUwZjE5YjM4OTQ5OGFiOGJiOTZjNjVhZDE4NWQzNDU5MjA2N2E3ZDAzM2FjNDhkZSJ9fX0=
-
-spawn-egg:
-  enabled: true # If the pet should have a spawn egg
-  item: magma_cube_spawn_egg unbreaking:1 hide_enchants
-  name: "&6Mancubus&f Spawn Egg"
-  lore:
-    - ""
-    - "&8&oPlace on the ground to"
-    - "&8&ounlock the &r&6Mancubus&8&o pet!"
-  craftable: false
-  recipe: [ ]
-  # recipe-permission: ecopets.craft.mancubus

--- a/eco-core/core-plugin/src/main/resources/pets/mancubus.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/mancubus.yml
@@ -4,18 +4,6 @@ description: "&8&oLevel up by taking damage while on fire"
 entity-texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTA5NWZjYzFlM2Q3Y2JkMzUwZjE5YjM4OTQ5OGFiOGJiOTZjNjVhZDE4NWQzNDU5MjA2N2E3ZDAzM2FjNDhkZSJ9fX0="
 icon: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTA5NWZjYzFlM2Q3Y2JkMzUwZjE5YjM4OTQ5OGFiOGJiOTZjNjVhZDE4NWQzNDU5MjA2N2E3ZDAzM2FjNDhkZSJ9fX0=
 
-spawn-egg:
-  enabled: true # If the pet should have a spawn egg
-  item: magma_cube_spawn_egg unbreaking:1 hide_enchants
-  name: "&6Mancubus&f Spawn Egg"
-  lore:
-    - ""
-    - "&8&oPlace on the ground to"
-    - "&8&ounlock the &r&6Mancubus&8&o pet!"
-  craftable: false
-  recipe: [ ]
-  recipe-permission: ecopets.craft.mancubus
-
 level-xp-requirements:
   - 50
   - 125
@@ -101,3 +89,15 @@ effects:
       - melee_attack
 
 conditions: [ ]
+
+spawn-egg:
+  enabled: true # If the pet should have a spawn egg
+  item: magma_cube_spawn_egg unbreaking:1 hide_enchants
+  name: "&6Mancubus&f Spawn Egg"
+  lore:
+    - ""
+    - "&8&oPlace on the ground to"
+    - "&8&ounlock the &r&6Mancubus&8&o pet!"
+  craftable: false
+  recipe: [ ]
+  recipe-permission: ecopets.craft.mancubus

--- a/eco-core/core-plugin/src/main/resources/pets/ravager.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/ravager.yml
@@ -1,6 +1,21 @@
 name: "<gradient:#1e3c72>Ravager</gradient:#2a5298>"
 description: "&8&oLevel up by successfully defending against village raids"
 
+entity-texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2QyMGJmNTJlYzM5MGEwNzk5Mjk5MTg0ZmM2NzhiZjg0Y2Y3MzJiYjFiZDc4ZmQxYzRiNDQxODU4ZjAyMzVhOCJ9fX0="
+icon: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2QyMGJmNTJlYzM5MGEwNzk5Mjk5MTg0ZmM2NzhiZjg0Y2Y3MzJiYjFiZDc4ZmQxYzRiNDQxODU4ZjAyMzVhOCJ9fX0=
+
+spawn-egg:
+  enabled: true
+  item: ravager_spawn_egg unbreaking:1 hide_enchants
+  name: "<gradient:#1e3c72>Ravager</gradient:#2a5298>&f Pet Spawn Egg"
+  lore:
+    - ""
+    - "&8&oPlace on the ground to"
+    - "&8&ounlock the &r<gradient:#1e3c72>Ravager</gradient:#2a5298>&8&o pet!"
+  craftable: false
+  recipe: [ ]
+  recipe-permission: ecopets.craft.ravager
+
 level-xp-requirements:
   - 50
   - 150
@@ -72,7 +87,7 @@ level-up-messages:
   1:
     - "&8» &8Gives a &a+%health_boost%%&8 bonus"
 
-level-commands: [ ]
+level-up-effects: [ ]
 
 effects:
   - id: bonus_health
@@ -80,18 +95,3 @@ effects:
       health: "%level%"
 
 conditions: [ ]
-
-entity-texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2QyMGJmNTJlYzM5MGEwNzk5Mjk5MTg0ZmM2NzhiZjg0Y2Y3MzJiYjFiZDc4ZmQxYzRiNDQxODU4ZjAyMzVhOCJ9fX0="
-
-icon: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2QyMGJmNTJlYzM5MGEwNzk5Mjk5MTg0ZmM2NzhiZjg0Y2Y3MzJiYjFiZDc4ZmQxYzRiNDQxODU4ZjAyMzVhOCJ9fX0=
-
-spawn-egg:
-  enabled: true
-  item: ravager_spawn_egg unbreaking:1 hide_enchants
-  name: "<gradient:#1e3c72>Ravager</gradient:#2a5298>&f Pet Spawn Egg"
-  lore:
-    - ""
-    - "&8&oPlace on the ground to"
-    - "&8&ounlock the &r<gradient:#1e3c72>Ravager</gradient:#2a5298>&8&o pet!"
-  craftable: false
-  recipe: [ ]

--- a/eco-core/core-plugin/src/main/resources/pets/ravager.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/ravager.yml
@@ -4,18 +4,6 @@ description: "&8&oLevel up by successfully defending against village raids"
 entity-texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2QyMGJmNTJlYzM5MGEwNzk5Mjk5MTg0ZmM2NzhiZjg0Y2Y3MzJiYjFiZDc4ZmQxYzRiNDQxODU4ZjAyMzVhOCJ9fX0="
 icon: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvY2QyMGJmNTJlYzM5MGEwNzk5Mjk5MTg0ZmM2NzhiZjg0Y2Y3MzJiYjFiZDc4ZmQxYzRiNDQxODU4ZjAyMzVhOCJ9fX0=
 
-spawn-egg:
-  enabled: true
-  item: ravager_spawn_egg unbreaking:1 hide_enchants
-  name: "<gradient:#1e3c72>Ravager</gradient:#2a5298>&f Pet Spawn Egg"
-  lore:
-    - ""
-    - "&8&oPlace on the ground to"
-    - "&8&ounlock the &r<gradient:#1e3c72>Ravager</gradient:#2a5298>&8&o pet!"
-  craftable: false
-  recipe: [ ]
-  recipe-permission: ecopets.craft.ravager
-
 level-xp-requirements:
   - 50
   - 150
@@ -95,3 +83,15 @@ effects:
       health: "%level%"
 
 conditions: [ ]
+
+spawn-egg:
+  enabled: true
+  item: ravager_spawn_egg unbreaking:1 hide_enchants
+  name: "<gradient:#1e3c72>Ravager</gradient:#2a5298>&f Pet Spawn Egg"
+  lore:
+    - ""
+    - "&8&oPlace on the ground to"
+    - "&8&ounlock the &r<gradient:#1e3c72>Ravager</gradient:#2a5298>&8&o pet!"
+  craftable: false
+  recipe: [ ]
+  recipe-permission: ecopets.craft.ravager

--- a/eco-core/core-plugin/src/main/resources/pets/sea_serpent.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/sea_serpent.yml
@@ -1,6 +1,21 @@
 name: "&9Sea Serpent"
 description: "&8&oIncrease swimming speed and damage in water. Level up by swimming"
 
+entity-texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTA5NWZjYzFlM2Q3Y2JkMzUwZjE5YjM4OTQ5OGFiOGJiOTZjNjVhZDE4NWQzNDU5MjA2N2E3ZDAzM2FjNDhkZSJ9fX0="
+icon: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTA5NWZjYzFlM2Q3Y2JkMzUwZjE5YjM4OTQ5OGFiOGJiOTZjNjVhZDE4NWQzNDU5MjA2N2E3ZDAzM2FjNDhkZSJ9fX0=
+
+spawn-egg:
+  enabled: true # If the pet should have a spawn egg
+  item: drowned_spawn_egg unbreaking:1 hide_enchants
+  name: "&9Sea Serpent&f Spawn Egg"
+  lore:
+    - ""
+    - "&8&oPlace on the ground to"
+    - "&8&ounlock the &r&9Sea Serpent&8&o pet!"
+  craftable: false
+  recipe: [ ]
+  recipe-permission: ecopets.craft.sea_serpent
+
 level-xp-requirements:
   - 50
   - 125
@@ -89,7 +104,7 @@ level-up-messages:
     - "&8» &8Gives a &a+%multiply_velocity%%&8 bonus to"
     - "   &8movement speed when in water"
 
-level-commands: [ ]
+level-up-effects: [ ]
 
 effects:
   - id: damage_multiplier
@@ -103,18 +118,3 @@ effects:
 
 conditions:
   - id: in_water
-
-entity-texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTA5NWZjYzFlM2Q3Y2JkMzUwZjE5YjM4OTQ5OGFiOGJiOTZjNjVhZDE4NWQzNDU5MjA2N2E3ZDAzM2FjNDhkZSJ9fX0="
-
-icon: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTA5NWZjYzFlM2Q3Y2JkMzUwZjE5YjM4OTQ5OGFiOGJiOTZjNjVhZDE4NWQzNDU5MjA2N2E3ZDAzM2FjNDhkZSJ9fX0=
-
-spawn-egg:
-  enabled: true # If the pet should have a spawn egg
-  item: drowned_spawn_egg unbreaking:1 hide_enchants
-  name: "&9Sea Serpent&f Spawn Egg"
-  lore:
-    - ""
-    - "&8&oPlace on the ground to"
-    - "&8&ounlock the &r&9Sea Serpent&8&o pet!"
-  craftable: false
-  recipe: [ ]

--- a/eco-core/core-plugin/src/main/resources/pets/sea_serpent.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/sea_serpent.yml
@@ -4,18 +4,6 @@ description: "&8&oIncrease swimming speed and damage in water. Level up by swimm
 entity-texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTA5NWZjYzFlM2Q3Y2JkMzUwZjE5YjM4OTQ5OGFiOGJiOTZjNjVhZDE4NWQzNDU5MjA2N2E3ZDAzM2FjNDhkZSJ9fX0="
 icon: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTA5NWZjYzFlM2Q3Y2JkMzUwZjE5YjM4OTQ5OGFiOGJiOTZjNjVhZDE4NWQzNDU5MjA2N2E3ZDAzM2FjNDhkZSJ9fX0=
 
-spawn-egg:
-  enabled: true # If the pet should have a spawn egg
-  item: drowned_spawn_egg unbreaking:1 hide_enchants
-  name: "&9Sea Serpent&f Spawn Egg"
-  lore:
-    - ""
-    - "&8&oPlace on the ground to"
-    - "&8&ounlock the &r&9Sea Serpent&8&o pet!"
-  craftable: false
-  recipe: [ ]
-  recipe-permission: ecopets.craft.sea_serpent
-
 level-xp-requirements:
   - 50
   - 125
@@ -118,3 +106,15 @@ effects:
 
 conditions:
   - id: in_water
+
+spawn-egg:
+  enabled: true # If the pet should have a spawn egg
+  item: drowned_spawn_egg unbreaking:1 hide_enchants
+  name: "&9Sea Serpent&f Spawn Egg"
+  lore:
+    - ""
+    - "&8&oPlace on the ground to"
+    - "&8&ounlock the &r&9Sea Serpent&8&o pet!"
+  craftable: false
+  recipe: [ ]
+  recipe-permission: ecopets.craft.sea_serpent

--- a/eco-core/core-plugin/src/main/resources/pets/skeleton.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/skeleton.yml
@@ -1,6 +1,21 @@
 name: "<gradient:#F2F2F2>Skeleton</gradient:#DBDBDB>"
 description: "&8&oLevel up by dealing bow damage"
 
+entity-texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOWQ0NmViNjQyZGMzYTRkZmJiNWFkNTI5N2VkYWUyOTk2ZWE0Y2ZmZjkyYWMyZWI1NmRmYWU5ZWUxZDU4ZTQwOCJ9fX0="
+icon: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOWQ0NmViNjQyZGMzYTRkZmJiNWFkNTI5N2VkYWUyOTk2ZWE0Y2ZmZjkyYWMyZWI1NmRmYWU5ZWUxZDU4ZTQwOCJ9fX0=
+
+spawn-egg:
+  enabled: true # If the pet should have a spawn egg
+  item: skeleton_spawn_egg unbreaking:1 hide_enchants
+  name: "<gradient:#F2F2F2>Skeleton</gradient:#DBDBDB>&f Pet Spawn Egg"
+  lore:
+    - ""
+    - "&8&oPlace on the ground to"
+    - "&8&ounlock the &r<gradient:#F2F2F2>Skeleton</gradient:#DBDBDB>&8&o pet!"
+  craftable: false
+  recipe: [ ]
+    recipe-permission: ecopets.craft.skeleton
+
 level-xp-requirements:
   - 50
   - 125
@@ -75,7 +90,7 @@ level-up-messages:
     - "&8» &8Gives a &a+%damage_multiplier%%&8 bonus to"
     - "   &8bow damage"
 
-level-commands: [ ]
+level-up-effects: [ ]
 
 effects:
   - id: damage_multiplier
@@ -83,19 +98,5 @@ effects:
       multiplier: "%level% * 0.01 + 1"
     triggers:
       - bow_attack
+      -
 conditions: [ ]
-
-entity-texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOWQ0NmViNjQyZGMzYTRkZmJiNWFkNTI5N2VkYWUyOTk2ZWE0Y2ZmZjkyYWMyZWI1NmRmYWU5ZWUxZDU4ZTQwOCJ9fX0="
-
-icon: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOWQ0NmViNjQyZGMzYTRkZmJiNWFkNTI5N2VkYWUyOTk2ZWE0Y2ZmZjkyYWMyZWI1NmRmYWU5ZWUxZDU4ZTQwOCJ9fX0=
-
-spawn-egg:
-  enabled: true # If the pet should have a spawn egg
-  item: skeleton_spawn_egg unbreaking:1 hide_enchants
-  name: "<gradient:#F2F2F2>Skeleton</gradient:#DBDBDB>&f Pet Spawn Egg"
-  lore:
-    - ""
-    - "&8&oPlace on the ground to"
-    - "&8&ounlock the &r<gradient:#F2F2F2>Skeleton</gradient:#DBDBDB>&8&o pet!"
-  craftable: false
-  recipe: [ ]

--- a/eco-core/core-plugin/src/main/resources/pets/skeleton.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/skeleton.yml
@@ -4,18 +4,6 @@ description: "&8&oLevel up by dealing bow damage"
 entity-texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOWQ0NmViNjQyZGMzYTRkZmJiNWFkNTI5N2VkYWUyOTk2ZWE0Y2ZmZjkyYWMyZWI1NmRmYWU5ZWUxZDU4ZTQwOCJ9fX0="
 icon: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOWQ0NmViNjQyZGMzYTRkZmJiNWFkNTI5N2VkYWUyOTk2ZWE0Y2ZmZjkyYWMyZWI1NmRmYWU5ZWUxZDU4ZTQwOCJ9fX0=
 
-spawn-egg:
-  enabled: true # If the pet should have a spawn egg
-  item: skeleton_spawn_egg unbreaking:1 hide_enchants
-  name: "<gradient:#F2F2F2>Skeleton</gradient:#DBDBDB>&f Pet Spawn Egg"
-  lore:
-    - ""
-    - "&8&oPlace on the ground to"
-    - "&8&ounlock the &r<gradient:#F2F2F2>Skeleton</gradient:#DBDBDB>&8&o pet!"
-  craftable: false
-  recipe: [ ]
-    recipe-permission: ecopets.craft.skeleton
-
 level-xp-requirements:
   - 50
   - 125
@@ -100,3 +88,15 @@ effects:
       - bow_attack
       -
 conditions: [ ]
+
+spawn-egg:
+  enabled: true # If the pet should have a spawn egg
+  item: skeleton_spawn_egg unbreaking:1 hide_enchants
+  name: "<gradient:#F2F2F2>Skeleton</gradient:#DBDBDB>&f Pet Spawn Egg"
+  lore:
+    - ""
+    - "&8&oPlace on the ground to"
+    - "&8&ounlock the &r<gradient:#F2F2F2>Skeleton</gradient:#DBDBDB>&8&o pet!"
+  craftable: false
+  recipe: [ ]
+  recipe-permission: ecopets.craft.skeleton

--- a/eco-core/core-plugin/src/main/resources/pets/skeleton.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/skeleton.yml
@@ -86,7 +86,7 @@ effects:
       multiplier: "%level% * 0.01 + 1"
     triggers:
       - bow_attack
-      -
+
 conditions: [ ]
 
 spawn-egg:

--- a/eco-core/core-plugin/src/main/resources/pets/tiger.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/tiger.yml
@@ -4,18 +4,6 @@ description: "&8&oLevel up by dealing melee damage"
 entity-texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTA5NWZjYzFlM2Q3Y2JkMzUwZjE5YjM4OTQ5OGFiOGJiOTZjNjVhZDE4NWQzNDU5MjA2N2E3ZDAzM2FjNDhkZSJ9fX0="
 icon: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTA5NWZjYzFlM2Q3Y2JkMzUwZjE5YjM4OTQ5OGFiOGJiOTZjNjVhZDE4NWQzNDU5MjA2N2E3ZDAzM2FjNDhkZSJ9fX0=
 
-spawn-egg:
-  enabled: true
-  item: blaze_spawn_egg unbreaking:1 hide_enchants
-  name: "&6Tiger&f Pet Spawn Egg"
-  lore:
-    - ""
-    - "&8&oPlace on the ground to"
-    - "&8&ounlock the &r&6Tiger&8&o pet!"
-  craftable: false
-  recipe: [ ]
-  recipe-permission: ecopets.craft.tiger
-
 level-xp-requirements:
   - 50
   - 125
@@ -101,3 +89,15 @@ effects:
       - melee_attack
 
 conditions: [ ]
+
+spawn-egg:
+  enabled: true
+  item: blaze_spawn_egg unbreaking:1 hide_enchants
+  name: "&6Tiger&f Pet Spawn Egg"
+  lore:
+    - ""
+    - "&8&oPlace on the ground to"
+    - "&8&ounlock the &r&6Tiger&8&o pet!"
+  craftable: false
+  recipe: [ ]
+  recipe-permission: ecopets.craft.tiger

--- a/eco-core/core-plugin/src/main/resources/pets/tiger.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/tiger.yml
@@ -1,6 +1,21 @@
 name: "&6Tiger"
 description: "&8&oLevel up by dealing melee damage"
 
+entity-texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTA5NWZjYzFlM2Q3Y2JkMzUwZjE5YjM4OTQ5OGFiOGJiOTZjNjVhZDE4NWQzNDU5MjA2N2E3ZDAzM2FjNDhkZSJ9fX0="
+icon: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTA5NWZjYzFlM2Q3Y2JkMzUwZjE5YjM4OTQ5OGFiOGJiOTZjNjVhZDE4NWQzNDU5MjA2N2E3ZDAzM2FjNDhkZSJ9fX0=
+
+spawn-egg:
+  enabled: true
+  item: blaze_spawn_egg unbreaking:1 hide_enchants
+  name: "&6Tiger&f Pet Spawn Egg"
+  lore:
+    - ""
+    - "&8&oPlace on the ground to"
+    - "&8&ounlock the &r&6Tiger&8&o pet!"
+  craftable: false
+  recipe: [ ]
+  recipe-permission: ecopets.craft.tiger
+
 level-xp-requirements:
   - 50
   - 125
@@ -76,7 +91,7 @@ level-up-messages:
     - "&8» &8Gives a &a+%damage_multiplier%%&8 bonus to"
     - "   &8melee damage"
 
-level-commands: [ ]
+level-up-effects: [ ]
 
 effects:
   - id: damage_multiplier
@@ -86,18 +101,3 @@ effects:
       - melee_attack
 
 conditions: [ ]
-
-entity-texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTA5NWZjYzFlM2Q3Y2JkMzUwZjE5YjM4OTQ5OGFiOGJiOTZjNjVhZDE4NWQzNDU5MjA2N2E3ZDAzM2FjNDhkZSJ9fX0="
-
-icon: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTA5NWZjYzFlM2Q3Y2JkMzUwZjE5YjM4OTQ5OGFiOGJiOTZjNjVhZDE4NWQzNDU5MjA2N2E3ZDAzM2FjNDhkZSJ9fX0=
-
-spawn-egg:
-  enabled: true
-  item: blaze_spawn_egg unbreaking:1 hide_enchants
-  name: "&6Tiger&f Pet Spawn Egg"
-  lore:
-    - ""
-    - "&8&oPlace on the ground to"
-    - "&8&ounlock the &r&6Tiger&8&o pet!"
-  craftable: false
-  recipe: [ ]

--- a/eco-core/core-plugin/src/main/resources/pets/vampire.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/vampire.yml
@@ -1,160 +1,160 @@
-  name: "<gradient:#A50000>Vampire</gradient:#FD2424>"
-  description: "&8&oLevel up by taking damage at night."
+name: "<gradient:#A50000>Vampire</gradient:#FD2424>"
+description: "&8&oLevel up by taking damage at night."
 
-  level-xp-requirements:
-    - 50
-    - 75
-    - 100
-    - 150
-    - 200
-    - 300
-    - 400
-    - 500
-    - 750
-    - 1000
-    - 1300
-    - 1500
-    - 1750
-    - 2000
-    - 2300
-    - 2500
-    - 3000
-    - 3500
-    - 4000
-    - 4500
-    - 5000
-    - 6000
-    - 8000
-    - 10000
-    - 12000
-    - 15000
-    - 20000
-    - 25000
-    - 30000
-    - 35000
-    - 40000
-    - 44500
-    - 50000
-    - 57000
-    - 64000
-    - 71000
-    - 78000
-    - 80000
-    - 85000
-    - 90000
-    - 95000
-    - 100000
-    - 110000
-    - 115000
-    - 120000
-    - 125000
-    - 150000
-    - 175000
-    - 200000
+entity-texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMzgyMGExMGRiMjIyZjY5YWMyMjE1ZDdkMTBkY2E0N2VlYWZhMjE1NTUzNzY0YTJiODFiYWZkNDc5ZTc5MzNkMSJ9fX0="
+icon: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMzgyMGExMGRiMjIyZjY5YWMyMjE1ZDdkMTBkY2E0N2VlYWZhMjE1NTUzNzY0YTJiODFiYWZkNDc5ZTc5MzNkMSJ9fX0=
 
-  xp-gain-methods:
-    - id: take_damage
-      multiplier: 10.0
-      conditions:
-        - id: is_night
+spawn-egg:
+  enabled: true
+  item: bat_spawn_egg unbreaking:2 hide_enchants
+  name: "<gradient:#A50000>Vampire</gradient:#FD2424>&f Pet Spawn Egg"
+  lore:
+    - ""
+    - "&8&oPlace on the ground to"
+    - "&8&ounlock the &r<gradient:#A50000>Vampire</gradient:#FD2424>&8&o pet!"
+  craftable: false
+  recipe: [ ]
+  recipe-permission: ecopets.craft.vampire
+
+level-xp-requirements:
+  - 50
+  - 75
+  - 100
+  - 150
+  - 200
+  - 300
+  - 400
+  - 500
+  - 750
+  - 1000
+  - 1300
+  - 1500
+  - 1750
+  - 2000
+  - 2300
+  - 2500
+  - 3000
+  - 3500
+  - 4000
+  - 4500
+  - 5000
+  - 6000
+  - 8000
+  - 10000
+  - 12000
+  - 15000
+  - 20000
+  - 25000
+  - 30000
+  - 35000
+  - 40000
+  - 44500
+  - 50000
+  - 57000
+  - 64000
+  - 71000
+  - 78000
+  - 80000
+  - 85000
+  - 90000
+  - 95000
+  - 100000
+  - 110000
+  - 115000
+  - 120000
+  - 125000
+  - 150000
+  - 175000
+  - 200000
+
+xp-gain-methods:
+  - id: take_damage
+    multiplier: 10.0
+    conditions:
+      - id: is_night
 
 
-  level-placeholders:
-    - id: "lifesteal_chance"
-      value: "%level%"
-    - id: "lifesteal_cooldown"
-      value: "1-(%level%/200)"
-    - id: "lifesteal_heal"
-      value: "%level%/20"
-    - id: "bleed_damage"
-      value: "(%level%-15)/10"
-    - id: "bleed_chance"
-      value: "%level%-10"
+level-placeholders:
+  - id: "lifesteal_chance"
+    value: "%level%"
+  - id: "lifesteal_cooldown"
+    value: "1-(%level%/200)"
+  - id: "lifesteal_heal"
+    value: "%level%/20"
+  - id: "bleed_damage"
+    value: "(%level%-15)/10"
+  - id: "bleed_chance"
+    value: "%level%-10"
 
-  effects-description:
-    1:
-      - "&8» &#ff0000This pet can ONLY be levelled at night."
-      - ""
-      - "&8» &7When hitting enemies have a &#ff0000%lifesteal_chance%% &7to gain"
-      - "    &7health from your enemy. Has a &#ff0000%lifesteal_cooldown% &7second cooldown."
-    25:
-      - "&8» &#ff0000This pet can ONLY be levelled at night."
-      - ""
-      - "&8» &7When hitting enemies have a &#ff0000%lifesteal_chance%% &7to gain"
-      - "    &7health from your enemy. Has a &#ff0000%lifesteal_cooldown% &7second cooldown."
-      - ""
-      - "&8» &7When hitting enemies have a &#ff0000%bleed_chance%% &7to bleed"
-      - "    &7your enemies dealing &#ff0000%bleed_damage%&7 damage twice."
+effects-description:
+  1:
+    - "&8» &#ff0000This pet can ONLY be levelled at night."
+    - ""
+    - "&8» &7When hitting enemies have a &#ff0000%lifesteal_chance%% &7to gain"
+    - "    &7health from your enemy. Has a &#ff0000%lifesteal_cooldown% &7second cooldown."
+  25:
+    - "&8» &#ff0000This pet can ONLY be levelled at night."
+    - ""
+    - "&8» &7When hitting enemies have a &#ff0000%lifesteal_chance%% &7to gain"
+    - "    &7health from your enemy. Has a &#ff0000%lifesteal_cooldown% &7second cooldown."
+    - ""
+    - "&8» &7When hitting enemies have a &#ff0000%bleed_chance%% &7to bleed"
+    - "    &7your enemies dealing &#ff0000%bleed_damage%&7 damage twice."
 
-  rewards-description:
-    1:
-      - "&8» &#ff0000This pet can ONLY be levelled at night."
-      - ""
-      - "&8» &7When hitting enemies have a &#ff0000%lifesteal_chance%% &7to gain &ff0000%lifesteal_heal%"
-      - "    &7health from your enemy. Has a &#ff0000%lifesteal_cooldown% &7second cooldown."
-    25:
-      - "&8» &#ff0000This pet can ONLY be levelled at night."
-      - ""
-      - "&8» &7When hitting enemies have a &#ff0000%lifesteal_chance%% &7to gain"
-      - "    &7health from your enemy. Has a &#ff0000%lifesteal_cooldown% &7second cooldown."
-      - ""
-      - "&8» &7When hitting enemies have a &#ff0000%bleed_chance%% &7to bleed"
-      - "    &7your enemies dealing &#ff0000%bleed_damage%&7 damage twice."
+rewards-description:
+  1:
+    - "&8» &#ff0000This pet can ONLY be levelled at night."
+    - ""
+    - "&8» &7When hitting enemies have a &#ff0000%lifesteal_chance%% &7to gain &ff0000%lifesteal_heal%"
+    - "    &7health from your enemy. Has a &#ff0000%lifesteal_cooldown% &7second cooldown."
+  25:
+    - "&8» &#ff0000This pet can ONLY be levelled at night."
+    - ""
+    - "&8» &7When hitting enemies have a &#ff0000%lifesteal_chance%% &7to gain"
+    - "    &7health from your enemy. Has a &#ff0000%lifesteal_cooldown% &7second cooldown."
+    - ""
+    - "&8» &7When hitting enemies have a &#ff0000%bleed_chance%% &7to bleed"
+    - "    &7your enemies dealing &#ff0000%bleed_damage%&7 damage twice."
 
-  level-up-messages:
-    1:
-      - "&8» &#ff0000This pet can ONLY be levelled at night."
-      - ""
-      - "&8» &7When hitting enemies have a &#ff0000%lifesteal_chance%% &7to gain"
-      - "    &7health from your enemy. Has a &#ff0000%lifesteal_cooldown% &7second cooldown."
-    25:
-      - "&8» &#ff0000This pet can ONLY be levelled at night."
-      - ""
-      - "&8» &7When hitting enemies have a &#ff0000%lifesteal_chance%% &7to gain"
-      - "    &7health from your enemy. Has a &#ff0000%lifesteal_cooldown% &7second cooldown."
-      - ""
-      - "&8» &7When hitting enemies have a &#ff0000%bleed_chance%% &7to bleed"
-      - "    &7your enemies dealing &#ff0000%bleed_damage%&7 damage twice."
+level-up-messages:
+  1:
+    - "&8» &#ff0000This pet can ONLY be levelled at night."
+    - ""
+    - "&8» &7When hitting enemies have a &#ff0000%lifesteal_chance%% &7to gain"
+    - "    &7health from your enemy. Has a &#ff0000%lifesteal_cooldown% &7second cooldown."
+  25:
+    - "&8» &#ff0000This pet can ONLY be levelled at night."
+    - ""
+    - "&8» &7When hitting enemies have a &#ff0000%lifesteal_chance%% &7to gain"
+    - "    &7health from your enemy. Has a &#ff0000%lifesteal_cooldown% &7second cooldown."
+    - ""
+    - "&8» &7When hitting enemies have a &#ff0000%bleed_chance%% &7to bleed"
+    - "    &7your enemies dealing &#ff0000%bleed_damage%&7 damage twice."
 
-  level-commands: [ ]
+level-up-effects: [ ]
 
-  effects:
-    - id: give_health
-      args:
-        chance: "%level%"
-        cooldown: "1-(%level%/200)"
-        send_cooldown_message: false
-        amount: "%level%/20"
-      triggers:
-        - melee_attack
+effects:
+  - id: give_health
+    args:
+      chance: "%level%"
+      cooldown: "1-(%level%/200)"
+      send_cooldown_message: false
+      amount: "%level%/20"
+    triggers:
+      - melee_attack
 
-    - id: bleed
-      args:
-        chance: "%level%-10"
-        damage: "(%level%-15)/10"
-        interval: 15
-        amount: 2
-      conditions:
-        - id: has_pet_level
-          args:
-            pet: vampire
-            level: 25
-      triggers:
-        - melee_attack
+  - id: bleed
+    args:
+      chance: "%level%-10"
+      damage: "(%level%-15)/10"
+      interval: 15
+      amount: 2
+    conditions:
+      - id: has_pet_level
+        args:
+          pet: vampire
+          level: 25
+    triggers:
+      - melee_attack
 
-  conditions: []
-
-  entity-texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMzgyMGExMGRiMjIyZjY5YWMyMjE1ZDdkMTBkY2E0N2VlYWZhMjE1NTUzNzY0YTJiODFiYWZkNDc5ZTc5MzNkMSJ9fX0="
-
-  icon: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMzgyMGExMGRiMjIyZjY5YWMyMjE1ZDdkMTBkY2E0N2VlYWZhMjE1NTUzNzY0YTJiODFiYWZkNDc5ZTc5MzNkMSJ9fX0=
-
-  spawn-egg:
-    enabled: true
-    item: bat_spawn_egg unbreaking:2 hide_enchants
-    name: "<gradient:#A50000>Vampire</gradient:#FD2424>&f Pet Spawn Egg"
-    lore:
-      - ""
-      - "&8&oPlace on the ground to"
-      - "&8&ounlock the &r<gradient:#A50000>Vampire</gradient:#FD2424>&8&o pet!"
-    craftable: false
-    recipe: [ ]
+conditions: [ ]

--- a/eco-core/core-plugin/src/main/resources/pets/vampire.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/vampire.yml
@@ -4,18 +4,6 @@ description: "&8&oLevel up by taking damage at night."
 entity-texture: "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMzgyMGExMGRiMjIyZjY5YWMyMjE1ZDdkMTBkY2E0N2VlYWZhMjE1NTUzNzY0YTJiODFiYWZkNDc5ZTc5MzNkMSJ9fX0="
 icon: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMzgyMGExMGRiMjIyZjY5YWMyMjE1ZDdkMTBkY2E0N2VlYWZhMjE1NTUzNzY0YTJiODFiYWZkNDc5ZTc5MzNkMSJ9fX0=
 
-spawn-egg:
-  enabled: true
-  item: bat_spawn_egg unbreaking:2 hide_enchants
-  name: "<gradient:#A50000>Vampire</gradient:#FD2424>&f Pet Spawn Egg"
-  lore:
-    - ""
-    - "&8&oPlace on the ground to"
-    - "&8&ounlock the &r<gradient:#A50000>Vampire</gradient:#FD2424>&8&o pet!"
-  craftable: false
-  recipe: [ ]
-  recipe-permission: ecopets.craft.vampire
-
 level-xp-requirements:
   - 50
   - 75
@@ -158,3 +146,15 @@ effects:
       - melee_attack
 
 conditions: [ ]
+
+spawn-egg:
+  enabled: true
+  item: bat_spawn_egg unbreaking:2 hide_enchants
+  name: "<gradient:#A50000>Vampire</gradient:#FD2424>&f Pet Spawn Egg"
+  lore:
+    - ""
+    - "&8&oPlace on the ground to"
+    - "&8&ounlock the &r<gradient:#A50000>Vampire</gradient:#FD2424>&8&o pet!"
+  craftable: false
+  recipe: [ ]
+  recipe-permission: ecopets.craft.vampire


### PR DESCRIPTION
Just like in my recent EcoJobs PR, this modernises EcoPets to be in line with the same quality of EcoSkills (and now EcoJobs).

This PR adds in `xp-formula` and `max-level` into the configs.
This also deprecates `level-commands` and introducts `level-up-effects` to add consistency with other libreforge levelling plugins and modernises the configs.