### PR TITLE
Add scale support for skull pets

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,7 @@ allprojects {
 
     java {
         withSourcesJar()
-        toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+        toolchain.languageVersion.set(JavaLanguageVersion.of(21))
     }
 
     tasks {
@@ -59,7 +59,7 @@ allprojects {
 
         compileKotlin {
             compilerOptions {
-                jvmTarget.set(JvmTarget.JVM_17)
+                jvmTarget.set(JvmTarget.JVM_21)
             }
         }
 

--- a/eco-core/core-plugin/build.gradle.kts
+++ b/eco-core/core-plugin/build.gradle.kts
@@ -2,7 +2,7 @@ group = "com.willfp"
 version = rootProject.version
 
 dependencies {
-    compileOnly("io.papermc.paper:paper-api:1.19.3-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.7-R0.1-SNAPSHOT")
     compileOnly("com.github.ben-manes.caffeine:caffeine:3.0.2")
 
     implementation("com.willfp:ecomponent:1.3.0")

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/entity/ModelEnginePetEntity.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/entity/ModelEnginePetEntity.kt
@@ -12,7 +12,7 @@ class ModelEnginePetEntity(
     private val plugin: EcoPetsPlugin
 ) : PetEntity(pet) {
     override fun spawn(location: Location): ArmorStand {
-        val stand = emptyArmorStandAt(location, pet)
+        val stand = emptyArmorStandAt(location, pet, isSkull = false)
 
         val model = ModelEngineBridge.instance.createActiveModel(modelID) ?: return stand
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/entity/SkullPetEntity.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/entity/SkullPetEntity.kt
@@ -8,7 +8,7 @@ import org.bukkit.inventory.ItemStack
 
 class SkullPetEntity(pet: Pet) : PetEntity(pet) {
     override fun spawn(location: Location): ArmorStand {
-        val stand = emptyArmorStandAt(location, pet)
+        val stand = emptyArmorStandAt(location, pet, isSkull = true)
 
         val skull: ItemStack = SkullBuilder()
             .setSkullTexture(pet.entityTexture)

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -261,6 +261,7 @@ level-gui:
 pet-entity:
   enabled: true # If you disable this, there will be no floating pets
   name: "%player%&f's %pet%&f (Lvl. %level%)"
+  scale: 1 # Scale of the pet head entity only. (Default: 1, Min: 0.0625, Max: 16)
 
 level-up:
   message:


### PR DESCRIPTION
### Included Changes
- Added support for applying scale to ArmorStands that contain player heads (skulls).
- The scale is configurable via `pet-entity.scale` in the `config.yml`.
- The allowed range (0.0625 to 16.0) is validated, and the attribute is skipped if not available.

### Reason
Visual improvement and compatibility with custom pets.

<img width="856" height="512" alt="scale1" src="https://github.com/user-attachments/assets/139c9c10-5a31-4b94-8760-0711db23af04" />
<img width="856" height="512" alt="scale2" src="https://github.com/user-attachments/assets/f8c09ecf-da25-4884-9d70-d6fb93ec33eb" />
