### PR TITLE
Configurable pet location

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pet.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pet.kt
@@ -485,6 +485,12 @@ private val activePetKey: PersistentDataKey<String> = PersistentDataKey(
     ""
 )
 
+private val shouldHidePetKey: PersistentDataKey<Boolean> = PersistentDataKey(
+    EcoPetsPlugin.instance.namespacedKeyFactory.create("hide_pet"),
+    PersistentDataKeyType.BOOLEAN,
+    false
+)
+
 private val petEggKey = EcoPetsPlugin.instance.namespacedKeyFactory.create("pet_egg")
 
 var ItemStack.petEgg: Pet?
@@ -503,6 +509,10 @@ val OfflinePlayer.activePetLevel: PetLevel?
         val active = this.activePet ?: return null
         return this.getPetLevelObject(active)
     }
+
+var OfflinePlayer.shouldHidePet: Boolean
+    get() = this.profile.read(shouldHidePetKey)
+    set(value) = this.profile.write(shouldHidePetKey, value)
 
 fun OfflinePlayer.getPetLevel(pet: Pet): Int =
     this.profile.read(pet.levelKey)

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
@@ -72,8 +72,9 @@ class PetDisplay(
                 stand.teleport(location)
             }
 
-            if (!pet.entityTexture.contains(":")) {
-                stand.setRotation((20 * tick / (2 * PI)).toFloat(), 0f)
+            if (!pet.entityTexture.contains(":") && plugin.configYml.getBool("pet-entity.rotation")) {
+                val intensity = plugin.configYml.getDoubleOrNull("pet-entity.rotation-intensity") ?: 20.0
+                stand.setRotation((intensity * tick / (2 * PI)).toFloat(), 0f)
             }
         }
     }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
@@ -3,6 +3,7 @@ package com.willfp.ecopets.pets
 import com.willfp.eco.core.EcoPlugin
 import com.willfp.eco.util.NumberUtils
 import com.willfp.eco.util.formatEco
+import com.willfp.libreforge.getDoubleFromExpression
 import org.bukkit.Bukkit
 import org.bukkit.Location
 import org.bukkit.entity.ArmorStand
@@ -57,8 +58,15 @@ class PetDisplay(
                 .formatEco(player)
 
             val location = getLocation(player)
+            val offset = plugin.configYml.getDoubleOrNull("pet-entity.location-y-offset") ?: 0.0
+            val bobbing = plugin.configYml.getDoubleOrNull("pet-entity.bobbing-intensity") ?: 0.15
 
-            location.y += NumberUtils.fastSin(tick / (2 * PI) * 0.5) * 0.15
+
+            if (plugin.configYml.getBool("pet-entity.bobbing")) {
+                location.y += offset + NumberUtils.fastSin(tick / (2 * PI) * 0.5) * bobbing
+            } else {
+                location.y += offset
+            }
 
             if (location.world != null) {
                 stand.teleport(location)
@@ -72,7 +80,9 @@ class PetDisplay(
 
     private fun getLocation(player: Player): Location {
         val direction = player.eyeLocation.direction.clone().normalize()
-        val offset = direction.clone().multiply(-0.75)
+
+        val locationXZOffset = plugin.configYml.getDoubleOrNull("pet-entity.location_xz_offset") ?: 0.75
+        val offset = direction.clone().multiply(-locationXZOffset)
 
         val uuid = player.uniqueId
         val currentTime = System.currentTimeMillis()

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
@@ -41,6 +41,11 @@ class PetDisplay(
     }
 
     private fun tickPlayer(player: Player) {
+        if (player.shouldHidePet) {
+            remove(player)
+            return
+        }
+
         val stand = getOrNew(player) ?: return
         val pet = player.activePet
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetsGUI.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetsGUI.kt
@@ -53,6 +53,22 @@ object PetsGUI {
                     .build()
         }
 
+        val togglePetItemBuilder = { player: Player, _: Menu ->
+            val isPetVisible = !player.shouldHidePet
+
+            if (isPetVisible) {
+                ItemStackBuilder(Items.lookup(plugin.configYml.getString("gui.toggle.hide-pet.item")))
+                    .setDisplayName(plugin.configYml.getFormattedString("gui.toggle.hide-pet.name"))
+                    .addLoreLines(plugin.configYml.getFormattedStrings("gui.toggle.hide-pet.lore"))
+                    .build()
+            } else {
+                ItemStackBuilder(Items.lookup(plugin.configYml.getString("gui.toggle.show-pet.item")))
+                    .setDisplayName(plugin.configYml.getFormattedString("gui.toggle.show-pet.name"))
+                    .addLoreLines(plugin.configYml.getFormattedStrings("gui.toggle.show-pet.lore"))
+                    .build()
+            }
+        }
+
         val petIconBuilder = { player: Player, menu: Menu, index: Int ->
             val page = menu.getPage(player)
 
@@ -199,6 +215,16 @@ object PetsGUI {
                     onLeftClick { event, _ ->
                         val player = event.whoClicked as Player
                         player.activePet = null
+                    }
+                }
+            )
+
+            setSlot(plugin.configYml.getInt("gui.toggle.location.row"),
+                plugin.configYml.getInt("gui.toggle.location.column"),
+                slot(togglePetItemBuilder) {
+                    onLeftClick { event, _ ->
+                        val player = event.whoClicked as Player
+                        player.shouldHidePet = !player.shouldHidePet
                     }
                 }
             )

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -147,6 +147,23 @@ gui:
       row: 6
       column: 2
 
+  toggle:
+    hide-pet:
+      item: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvOTI1YjhlZWQ1YzU2NWJkNDQwZWM0N2M3OWMyMGQ1Y2YzNzAxNjJiMWQ5YjVkZDMxMDBlZDYyODNmZTAxZDZlIn19fQ==
+      name: "&cHide Pet"
+      lore:
+        - "&f"
+        - "&eClick to hide your pet"
+    show-pet:
+      item: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjNmNzliMjA3ZDYxZTEyMjUyM2I4M2Q2MTUwOGQ5OWNmYTA3OWQ0NWJmMjNkZjJhOWE1MTI3ZjkwNzFkNGIwMCJ9fX0=
+      name: "&aShow Pet"
+      lore:
+        - "&f"
+        - "&eClick to show your pet"
+    location:
+      row: 6
+      column: 8
+
   # Custom GUI slots; see here for a how-to: https://plugins.auxilor.io/all-plugins/custom-gui-slots
   custom-slots: [ ]
 

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -261,6 +261,10 @@ level-gui:
 pet-entity:
   enabled: true # If you disable this, there will be no floating pets
   name: "%player%&f's %pet%&f (Lvl. %level%)"
+  location-y-offset: 0.0 # How far the pet should be from the player on the Y axis (Default: 0.0)
+  location_xz_offset: 0.75 # How far the pet should be from the player on the X and Z axis (Default: 0.75)
+  bobbing: true # If the pet should bob up and down
+  bobbing-intensity: 1 # How much the pet should bob up and down (Default: 0.15)
 
 level-up:
   message:

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -265,6 +265,8 @@ pet-entity:
   location_xz_offset: 0.75 # How far the pet should be from the player on the X and Z axis (Default: 0.75)
   bobbing: true # If the pet should bob up and down
   bobbing-intensity: 1 # How much the pet should bob up and down (Default: 0.15)
+  rotation: true # If the pet should rotate/spin
+  rotation-intensity: 20 # How fast the pet should rotate/spin (Default: 20)
 
 level-up:
   message:


### PR DESCRIPTION
Configurable pet location, spin speed, and bounce intensity.
Adds toggle for hiding the entity but maintaining effects, please credit PillageDev for that change. They closed their PR when they deleted the repo, but the change was great and should definately be a feature. It's highly requested