### PR TITLE
Prevent tick overflow, improve ArmorStand scaling compatibility, and enhance sound playback robustness

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
@@ -3,7 +3,6 @@ package com.willfp.ecopets.pets
 import com.willfp.eco.core.EcoPlugin
 import com.willfp.eco.util.NumberUtils
 import com.willfp.eco.util.formatEco
-import com.willfp.libreforge.getDoubleFromExpression
 import org.bukkit.Bukkit
 import org.bukkit.Location
 import org.bukkit.entity.ArmorStand
@@ -30,6 +29,10 @@ class PetDisplay(
         }
 
         tick++
+        // Reset tick to prevent overflow
+        if (tick > 1_048_576) {
+            tick = 0
+        }
     }
 
     private val smoothYOffsetMap = mutableMapOf<UUID, Double>()

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetsGUI.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetsGUI.kt
@@ -123,12 +123,14 @@ object PetsGUI {
                             player.activePet = pet
                         }
 
-                        player.playSound(
-                            player.location,
-                            Sound.valueOf(plugin.configYml.getString("gui.pet-icon.click.sound").uppercase()),
-                            1f,
-                            plugin.configYml.getDouble("gui.pet-icon.click.pitch").toFloat()
-                        )
+                        try {
+                            val soundName = plugin.configYml.getString("gui.pet-icon.click.sound").uppercase()
+                            val soundMethod = Sound::class.java.getMethod("valueOf", String::class.java)
+                            val sound = soundMethod.invoke(null, soundName) as Sound
+                            player.playSound(player.location, sound, 1f, plugin.configYml.getDouble("gui.pet-icon.click.pitch").toFloat())
+                        } catch (e: Exception) {
+                            plugin.logger.warning("Failed to play sound for pet icon click: ${e.message}")
+                        }
                     }
                 })
             }

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/entity/PetEntity.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/entity/PetEntity.kt
@@ -47,14 +47,20 @@ private fun ArmorStand.applyScale(plugin: EcoPlugin, isSkull: Boolean) {
         return
     }
 
-    val scaleAttribute = getAttribute(Attribute.SCALE)
-    if (scaleAttribute == null) {
-        plugin.logger.warning("Failed to set scale - SCALE attribute not found on ArmorStand")
-        return
+    val scaleAttribute = try {
+        Attribute::class.java.getField("SCALE").get(null) as? Attribute
+    } catch (_: NoSuchFieldException) {
+        null
     }
 
-    scaleAttribute.baseValue = scale
-
+    if (scaleAttribute != null) {
+        val attr = getAttribute(scaleAttribute)
+        if (attr != null) {
+            attr.baseValue = scale
+        } else {
+            plugin.logger.warning("Failed to set scale - SCALE attribute not found on ArmorStand instance")
+        }
+    }
 }
 
 internal fun emptyArmorStandAt(location: Location, pet: Pet, isSkull: Boolean): ArmorStand {

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -284,7 +284,7 @@ pet-entity:
   bobbing-intensity: 1 # How much the pet should bob up and down (Default: 0.15)
   rotation: true # If the pet should rotate/spin
   rotation-intensity: 20 # How fast the pet should rotate/spin (Default: 20)
-  scale: 1 # Scale of the pet head entity only. (Default: 1, Min: 0.0625, Max: 16)
+  scale: 1 # Scale of the pet head entity only. (Default: 1, Min: 0.0625, Max: 16) (Only available for 1.21.3+)
 
 level-up:
   message:


### PR DESCRIPTION
This PR includes key fixes to enhance plugin stability and compatibility:

- **Prevent tick overflow:** Automatically resets the tick counter after 1,048,576 to avoid overflow errors.

- **Improve ArmorStand scale compatibility:** Adjusts how the `SCALE` attribute is retrieved to handle its absence in some server versions, preventing runtime errors.

- **Enhance GUI sound playback robustness:** Wraps `Sound.valueOf` in a try-catch block to avoid crashes due to invalid config values when playing the pet icon click sound.

These changes improve overall plugin reliability across different server versions and user configurations.
