### PR TITLE
QOL changes

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/EcoPetsPlugin.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/EcoPetsPlugin.kt
@@ -115,10 +115,6 @@ class EcoPetsPlugin : LibreforgePlugin() {
         }
     }
 
-    override fun handleDisable() {
-        petDisplay.shutdown()
-    }
-
     override fun loadIntegrationLoaders(): List<IntegrationLoader> {
         return listOf(
             IntegrationLoader("ModelEngine") {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
@@ -44,7 +44,7 @@ object PetDisplay : Listener {
     private val expireAfterMillis = 5_000L
 
     private fun tickPlayer(player: Player) {
-        if (player.shouldHidePet) {
+        if (player.shouldHidePet || player.isInvisible || player.isDead || !player.isOnline) {
             remove(player)
             return
         }
@@ -54,11 +54,6 @@ object PetDisplay : Listener {
         val showHologram = plugin.configYml.getBool("pet-entity.show-hologram")
 
         if (pet != null) {
-            if (player.isInvisible || player.isDead || !player.isOnline) {
-                remove(player)
-                return
-            }
-
             if (showHologram) {
                 @Suppress("DEPRECATION")
                 entity.customName = plugin.configYml.getString("pet-entity.name")
@@ -71,16 +66,32 @@ object PetDisplay : Listener {
                 entity.isCustomNameVisible = false
             }
 
+            // makes the pet follow the player's sneaking state (so the name can be hidden when sneaking)
+            if (player.isSneaking)
+                entity.isSneaking = true
+            else
+                entity.isSneaking = false
+
             val location = getLocation(player, if ((entity is ArmorStand)) 0.0 else 1.0)
             val offset = plugin.configYml.getDoubleOrNull("pet-entity.location-y-offset") ?: 0.0
             val bobbing = plugin.configYml.getDoubleOrNull("pet-entity.bobbing-intensity") ?: 0.15
 
+            val yOnPlayerSneaking = when {
+                player.isSneaking -> -0.3
+                else -> 0.0
+            }
 
+            // make the pet not be in the player's view when looking up or down
+            val yOnPlayerLookingUp = when {
+                player.pitch < -75 -> -1.5
+                player.pitch > 75 -> 0.5
+                else -> 0.0
+            }
 
             if (plugin.configYml.getBool("pet-entity.bobbing")) {
-                location.y += offset + NumberUtils.fastSin(tick / (2 * PI) * 0.5) * bobbing
+                location.y += yOnPlayerSneaking + yOnPlayerLookingUp + offset + NumberUtils.fastSin(tick / (2 * PI) * 0.5) * bobbing
             } else {
-                location.y += offset
+                location.y += yOnPlayerSneaking + yOnPlayerLookingUp + offset
             }
 
             if (location.world != null) {
@@ -164,19 +175,12 @@ object PetDisplay : Listener {
 
             val location = getLocation(player, 0.0)
             val entity = pet.makePetEntity().spawn(location)
+                .apply { isPersistent = false }
 
             trackedEntities[player.uniqueId] = PetDisplayEntity(entity, pet)
         }
 
         return trackedEntities[player.uniqueId]?.entity
-    }
-
-    fun shutdown() {
-        for (stand in trackedEntities.values) {
-            stand.entity.remove()
-        }
-
-        trackedEntities.clear()
     }
 
     private fun remove(player: Player) {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
@@ -67,10 +67,7 @@ object PetDisplay : Listener {
             }
 
             // makes the pet follow the player's sneaking state (so the name can be hidden when sneaking)
-            if (player.isSneaking)
-                entity.isSneaking = true
-            else
-                entity.isSneaking = false
+            entity.isSneaking = player.isSneaking
 
             val location = getLocation(player, if ((entity is ArmorStand)) 0.0 else 1.0)
             val offset = plugin.configYml.getDoubleOrNull("pet-entity.location-y-offset") ?: 0.0

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
@@ -94,13 +94,14 @@ object PetDisplay : Listener {
                 location.y += yOnPlayerSneaking + yOnPlayerLookingUp + offset
             }
 
-            if (location.world != null) {
-                entity.teleport(location)
-            }
-
             if (!pet.entityTexture.contains(":") && plugin.configYml.getBool("pet-entity.rotation")) {
                 val intensity = plugin.configYml.getDoubleOrNull("pet-entity.rotation-intensity") ?: 20.0
-                entity.setRotation((intensity * tick / (2 * PI)).toFloat(), 0f)
+                location.yaw = (intensity * tick / (2 * PI)).toFloat()
+                location.pitch = 0f
+            }
+
+            if (location.world != null) {
+                entity.teleport(location)
             }
         }
     }

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -285,7 +285,7 @@ pet-entity:
   location-y-offset: 0.0 # How far the pet should be from the player on the Y axis (Default: 0.0)
   location_xz_offset: 0.75 # How far the pet should be from the player on the X and Z axis (Default: 0.75)
   bobbing: true # If the pet should bob up and down
-  bobbing-intensity: 1 # How much the pet should bob up and down (Default: 0.15)
+  bobbing-intensity: 0.15 # How much the pet should bob up and down (Default: 0.15)
   rotation: true # If the pet should rotate/spin
   rotation-intensity: 20 # How fast the pet should rotate/spin (Default: 20)
   scale: 1 # Scale of the pet head entity only. (Default: 1, Min: 0.0625, Max: 16)

--- a/eco-core/core-plugin/src/main/resources/lang.yml
+++ b/eco-core/core-plugin/src/main/resources/lang.yml
@@ -3,7 +3,7 @@ messages:
   no-permission: "&cYou don't have permission to do this!"
   not-player: "&cThis command must be run by a player"
   invalid-command: "&cUnknown subcommand!"
-  reloaded: "Reloaded!"
+  reloaded: "Reloaded! Took %time%ms"
 
   needs-player: "&cYou must specify a player!"
   gave-xp: "&fYou have given &a%xp% &fXP to %player%&f's %pet%&f!"


### PR DESCRIPTION
Pets now are non-persistent, meaning they'll be removed from the server if the pet-entity ever unloads.
Pets now follow sneak state of players and hides their name.
Pets now moves bellow the player if the player looks up.
Pets now moves above the player if the player looks down.
Fixes default bobbing being set to 1 instead of 0.15.
Fixes pet going in and out of existence if player is dead or invisible (gamemode spectator usually).
Optimize pet's rotation.