### PR TITLE
fix: show infinity symbol for required_xp at max pet level

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pet.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pet.kt
@@ -458,7 +458,7 @@ class Pet(
      */
     fun getExpForLevel(level: Int): Double {
         if (level !in 1..maxLevel) {
-            return Double.MAX_VALUE
+            return Double.POSITIVE_INFINITY
         }
 
         if (xpFormula != null) {


### PR DESCRIPTION
**Summary**

- `%ecopets_active_pet_required_xp%` and the in-lore `%required_xp%` were displaying `1.7976931348623157E308` at max level instead of the infinity symbol
- Root cause: `Pet.getExpForLevel` returned `Double.MAX_VALUE` for out-of-range levels; the existing `isInfinite()` check in `getFormattedExpForLevel` never triggered because `MAX_VALUE` is finite
- Fix: swap the sentinel to `Double.POSITIVE_INFINITY` so the already-correct `isInfinite()` branch returns the lang-configured infinity symbol

**Testing**

- Pet below max level: `%ecopets_active_pet_required_xp%` shows a normal XP number (unchanged)
- Pet at max level: same placeholder shows infinity symbol
- Pet at max level: `%ecopets_active_pet_percentage_progress%` shows `0`
- Pet at max level, trigger XP gain: `%ecopets_active_pet_current_xp%` still increments (accumulation intentional)
- Pet GUI / lore at max level: `%required_xp%` shows infinity symbol
