### PR TITLE
fix: Admonition format

### DIFF
--- a/documentation/ecopets/how-to-make-a-custom-pet.md
+++ b/documentation/ecopets/how-to-make-a-custom-pet.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: How to make a Pet
 sidebar_position: 1
 ---
@@ -207,7 +207,7 @@ effects:
 ```
 
 ### The Effects Section
-:::dangerEffects Section
+:::danger Effects Section
 
 The effects section is the core functionality of the pet. You can configure effects, conditions, filters, mutators and triggers in this section to run whilst the pet is active.
 


### PR DESCRIPTION
Fixes missing space between admonition type and title in documentation (e.g. `:::dangerEffects Section` → `:::danger Effects Section`).