### PR TITLE
feat: add pet-egg withdrawal

### DIFF
--- a/documentation/ecopets/commands-and-permissions.md
+++ b/documentation/ecopets/commands-and-permissions.md
@@ -8,7 +8,7 @@ Every EcoPets command and permission node, for giving, resetting, importing, and
 | Command                                   | Description                                          | Permission                   |
 |-------------------------------------------|------------------------------------------------------|------------------------------|
 | `/ecopets give <player> <pet>`            | Give a pet                                           | `ecopets.command.give`       |
-| `/ecopets giveegg <player> <pet>`         | Give a pet egg                                       | `ecopets.command.give`       |
+| `/ecopets giveegg <player> <pet> [level] [xp]` | Give a pet egg, optionally at a level/xp        | `ecopets.command.give`       |
 | `/ecopets reset <player> <pet>`           | Reset a pet                                          | `ecopets.command.reset`      |
 | `/ecopets givexp <player> <pet> <amount>` | Give xp to a pet                                     | `ecopets.command.givexp`     |
 | `/pets`                                   | Open the pets menu                                   | `ecopets.command.pets`       |

--- a/documentation/ecopets/how-to-make-a-custom-pet.md
+++ b/documentation/ecopets/how-to-make-a-custom-pet.md
@@ -123,6 +123,12 @@ spawn-egg:
   craftable: false # Whether the egg can be crafted
   recipe: [ ]
   recipe-permission: ecopets.craft.tiger # Optional; permission needed to craft the egg
+  withdrawable: true # Allow players to withdraw this pet into a tradeable egg via the GUI
+  withdraw-price: # Optional cost to withdraw; omit or set enabled: false for free
+    enabled: false
+    type: coins
+    value: 10000
+    display: "%value% coins"
 ```
 
 ### Display
@@ -249,11 +255,41 @@ spawn-egg:
   craftable: false # Whether the egg can be crafted
   recipe: [ ]
   recipe-permission: ecopets.craft.tiger # Optional; permission needed to craft the egg
+  withdrawable: true # Allow players to withdraw this pet into a tradeable egg via the GUI
+  withdraw-price: # Optional cost to withdraw; omit or set enabled: false for free
+    enabled: false
+    type: coins
+    value: 10000
+    display: "%value% coins"
 ```
 
 :::tip
 We support shaped and shapeless recipes. Check out [Recipes](https://plugins.auxilor.io/the-item-lookup-system/recipes) for how to configure these.
 :::
+
+#### Withdrawal
+
+Set `withdrawable: true` to let players withdraw their active pet into a tradeable spawn egg from the pet GUI. The egg carries the pet's current level and XP; whoever redeems it unlocks the pet at the baked level. A confirm GUI prevents accidental withdrawals.
+
+```yaml
+withdrawable: true # Allow players to withdraw this pet into a tradeable egg via the GUI
+withdraw-price: # Optional cost to withdraw; omit or set enabled: false for free
+  enabled: false
+  type: coins
+  value: 10000
+  display: "%value% coins"
+```
+
+Set `withdraw-price.type` to `coins` for an economy cost, or to `<id>_pet_level` to charge pet levels instead. Remove the `withdraw-price` block entirely (or set `enabled: false`) to make withdrawal free.
+
+The egg `lore` supports these extra placeholders when displaying a withdrawn egg:
+
+| Placeholder | Value |
+| --- | --- |
+| `%level%` | The baked level stored in the egg |
+| `%current_xp%` | The baked XP stored in the egg |
+| `%level_numeral%` | The baked level as a Roman numeral |
+| `%level_+N%` / `%level_-N%` | The baked level offset by N, e.g. `%level_+1%` |
 
 ## Internal placeholders
 

--- a/documentation/ecopets/index.md
+++ b/documentation/ecopets/index.md
@@ -14,6 +14,7 @@ Every pet is defined in config, so you can build your own without writing any co
 - XP can come from any libreforge trigger (melee, mining, fishing, and more), with per-method multipliers and conditions.
 - Buffs use the same effects system as the rest of the eco ecosystem, so anything you can do with an effect, a pet can do.
 - Levels scale with a fixed list or an infinite formula, your choice.
+- Pets can be withdrawn into tradeable spawn eggs that carry the baked level and XP, so players can trade or gift their progress.
 
 <hr/>
 

--- a/documentation/ecopets/placeholderapi.md
+++ b/documentation/ecopets/placeholderapi.md
@@ -20,6 +20,7 @@ These placeholders expose a player's pet levels, XP, and active pet anywhere Pla
 | `%ecopets_active_pet_required_xp%`         | Shows the XP required for the active pet's next level                                 |
 | `%ecopets_pet%`                            | Shows the name of the active pet                                                      |
 | `%ecopets_pet_id%`                         | Shows the id of the active pet                                                        |
+| `%ecopets_<id>_withdraw_price%`            | Shows the withdrawal cost for the given pet for the viewing player                    |
 
 <hr/>
 

--- a/documentation/ecopets/plugin-config.md
+++ b/documentation/ecopets/plugin-config.md
@@ -19,6 +19,12 @@ use-local-storage: false
 
 discover-recipes: true
 
+# How redeeming a pet egg behaves when the player ALREADY owns that pet:
+# keep-higher - overwrite only if the egg's level is higher than the owned level, else reject
+# reject - never redeem if the pet is already owned (player must withdraw theirs first)
+pet-egg:
+  redeem-conflict: keep-higher
+
 # If a pet should be automatically deactivated when its activate-conditions are no longer met
 auto-deactivate-on-condition-fail: true
 
@@ -134,6 +140,13 @@ gui:
       volume: 1
       category: UI
 
+  page-change-sound:
+    enabled: true
+    sound: ui_button_click
+    pitch: 1
+    volume: 1
+    category: UI
+
   prev-page:
     item: arrow name:"&fPrevious Page"
     location:
@@ -161,6 +174,60 @@ gui:
     location:
       row: 6
       column: 2
+
+  withdraw-pet:
+    enabled: true
+    item: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYmFkYzA0OGE3Y2U3OGY3ZGFkNzJhMDdkYTI3ZDg1YzA5MTY4ODFlNTUyMmVlZWQxZTNkYWYyMTdhMzhjMWEifX19
+    name: "&cWithdraw Pet"
+    lore:
+      - "&7Withdraw your active pet into an egg"
+      - "&7you can trade or give to others."
+      - ""
+      - "&cYou will lose all progress on this pet!"
+      - "&7Cost: &e%withdraw_price%"
+    location:
+      row: 6
+      column: 3
+    confirm:
+      rows: 3
+      title: "&cConfirm Withdrawal"
+
+      mask:
+        materials:
+          - black_stained_glass_pane
+        pattern:
+          - "111111111"
+          - "100000001"
+          - "111111111"
+
+      confirm:
+        item: lime_stained_glass_pane
+        name: "&aConfirm Withdrawal"
+        lore:
+          - "&7Withdraw your active pet into an egg."
+        row: 2
+        column: 3
+        sound:
+          enabled: true
+          sound: ui_button_click
+          pitch: 1
+          volume: 1
+          category: UI
+      cancel:
+        item: red_stained_glass_pane
+        name: "&cCancel"
+        lore: [ ]
+        row: 2
+        column: 7
+        sound:
+          enabled: true
+          sound: ui_button_click
+          pitch: 1
+          volume: 1
+          category: UI
+
+      # Custom GUI slots; see here for a how-to: https://plugins.auxilor.io/all-plugins/custom-gui-slots
+      custom-slots: [ ]
 
   toggle:
     hide-pet:
@@ -219,6 +286,13 @@ level-gui:
 
     # If the amount of the item should be the level
     level-as-amount: true
+
+    page-change-sound:
+      enabled: true
+      sound: ui_button_click
+      pitch: 1
+      volume: 1
+      category: UI
 
     prev-page:
       item: arrow name:"&fPrevious Page"
@@ -316,8 +390,19 @@ level-up:
     pitch: 1.3
     volume: 0.8
     category: PLAYER
-
 ```
+
+## pet-egg
+
+Controls behaviour when a withdrawn spawn egg is redeemed.
+
+| Key | Values | Description |
+| --- | --- | --- |
+| `redeem-conflict` | `keep-higher`, `reject` | What happens when a player redeems an egg for a pet they already own. `keep-higher` keeps whichever level is higher (egg or existing); `reject` refuses the redemption and returns the egg. |
+
+## gui.withdraw-pet
+
+The withdraw button shown in the pet GUI when the active pet has `withdrawable: true` in its config. Clicking it opens the `confirm` sub-GUI before the withdrawal is processed and the egg is created. Use `%withdraw_price%` in the lore to show the configured cost for the current player.
 
 <hr/>
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/EcoPetsPlugin.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/EcoPetsPlugin.kt
@@ -3,10 +3,13 @@ package com.willfp.ecopets
 import com.willfp.eco.core.bstats.EcoMetricsChart
 import com.willfp.eco.core.command.impl.PluginCommand
 import com.willfp.eco.core.integrations.IntegrationLoader
+import com.willfp.eco.core.items.Items
 import com.willfp.eco.core.placeholder.PlayerPlaceholder
 import com.willfp.eco.util.StringUtils
 import com.willfp.ecopets.commands.CommandEcoPets
 import com.willfp.ecopets.commands.CommandPets
+import com.willfp.ecopets.items.ArgParserPetLevel
+import com.willfp.ecopets.items.ArgParserPetXp
 import com.willfp.ecopets.libreforge.ConditionHasActivePet
 import com.willfp.ecopets.libreforge.ConditionHasPet
 import com.willfp.ecopets.libreforge.ConditionHasPetLevel
@@ -76,6 +79,9 @@ class EcoPetsPlugin : LibreforgePlugin() {
         Filters.register(FilterPet)
         Mutators.register(MutatorPlayerToPet)
         Mutators.register(MutatorPlayerToPetLocation)
+
+        Items.registerArgParser(ArgParserPetLevel)
+        Items.registerArgParser(ArgParserPetXp)
 
         registerSpecificHolderProvider<Player> {
             it.activePetLevel?.let { p ->

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/commands/CommandGiveEgg.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/commands/CommandGiveEgg.kt
@@ -4,6 +4,7 @@ import com.willfp.eco.core.command.impl.Subcommand
 import com.willfp.eco.core.drops.DropQueue
 import com.willfp.eco.util.StringUtils
 import com.willfp.eco.util.savedDisplayName
+import com.willfp.eco.util.toNiceString
 import com.willfp.ecopets.pets.Pets
 import com.willfp.ecopets.plugin
 import org.bukkit.Bukkit
@@ -91,11 +92,22 @@ object CommandGiveEgg : Subcommand(
         }
 
         if (args.size == 3) {
-            return listOf("<level>")
+            val pet = Pets.getByID(args[1])
+            val maxLevel = pet?.maxLevel ?: 1
+            return listOf("1", "10", "50", maxLevel.toString()).distinct()
         }
 
         if (args.size == 4) {
-            return listOf("<xp>")
+            val pet = Pets.getByID(args[1])
+            val level = args[2].toIntOrNull() ?: 1
+            val maxXp = pet?.getExpForLevel(level)?.takeIf { it.isFinite() }
+
+            val options = listOf(10.0, 50.0, 100.0, 10000.0)
+            return if (maxXp != null) {
+                (options.filter { it < maxXp } + maxXp).distinct().map { it.toNiceString() }
+            } else {
+                options.map { it.toNiceString() }
+            }
         }
 
         return emptyList()

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/commands/CommandGiveEgg.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/commands/CommandGiveEgg.kt
@@ -38,9 +38,17 @@ object CommandGiveEgg : Subcommand(
 
         val pet = Pets.getByID(args[1])
 
-        val egg = pet?.spawnEgg
+        if (pet == null) {
+            sender.sendMessage(plugin.langYml.getMessage("invalid-pet"))
+            return
+        }
 
-        if (pet == null || egg == null) {
+        val level = args.getOrNull(2)?.toIntOrNull() ?: 1
+        val xp = args.getOrNull(3)?.toDoubleOrNull() ?: 0.0
+
+        val egg = pet.makeSpawnEgg(level, xp)
+
+        if (egg == null) {
             sender.sendMessage(plugin.langYml.getMessage("invalid-pet"))
             return
         }
@@ -80,6 +88,14 @@ object CommandGiveEgg : Subcommand(
                 completions
             )
             return completions
+        }
+
+        if (args.size == 3) {
+            return listOf("<level>")
+        }
+
+        if (args.size == 4) {
+            return listOf("<xp>")
         }
 
         return emptyList()

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/items/ArgParserPetLevel.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/items/ArgParserPetLevel.kt
@@ -1,0 +1,39 @@
+package com.willfp.ecopets.items
+
+import com.willfp.eco.core.items.args.LookupArgParser
+import com.willfp.ecopets.pets.Pets
+import com.willfp.ecopets.pets.petEggKey
+import com.willfp.ecopets.pets.petEggLevel
+import com.willfp.ecopets.pets.petEggLevelKey
+import com.willfp.ecopets.pets.petEggXpKey
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.ItemMeta
+import org.bukkit.persistence.PersistentDataType
+import java.util.function.Predicate
+
+object ArgParserPetLevel : LookupArgParser {
+    override fun parseArguments(args: Array<out String>, meta: ItemMeta): Predicate<ItemStack>? {
+        val arg = args.firstOrNull { it.startsWith("pet-level:") } ?: return null
+        val level = arg.substringAfter(":").toIntOrNull() ?: return null
+
+        meta.persistentDataContainer.set(petEggLevelKey, PersistentDataType.INTEGER, level)
+
+        val pdc = meta.persistentDataContainer
+        val petId = pdc.get(petEggKey, PersistentDataType.STRING)
+        val pet = petId?.let { Pets.getByID(it) }
+        if (pet != null) {
+            val xp = pdc.get(petEggXpKey, PersistentDataType.DOUBLE) ?: 0.0
+            pet.makeSpawnEgg(level, xp)?.itemMeta?.also { eggMeta ->
+                meta.displayName(eggMeta.displayName())
+                meta.lore(eggMeta.lore())
+            }
+        }
+
+        return Predicate { it.petEggLevel == level }
+    }
+
+    override fun serializeBack(meta: ItemMeta): String? {
+        val level = meta.persistentDataContainer.get(petEggLevelKey, PersistentDataType.INTEGER) ?: return null
+        return "pet-level:$level"
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/items/ArgParserPetXp.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/items/ArgParserPetXp.kt
@@ -1,0 +1,39 @@
+package com.willfp.ecopets.items
+
+import com.willfp.eco.core.items.args.LookupArgParser
+import com.willfp.ecopets.pets.Pets
+import com.willfp.ecopets.pets.petEggKey
+import com.willfp.ecopets.pets.petEggLevelKey
+import com.willfp.ecopets.pets.petEggXp
+import com.willfp.ecopets.pets.petEggXpKey
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.ItemMeta
+import org.bukkit.persistence.PersistentDataType
+import java.util.function.Predicate
+
+object ArgParserPetXp : LookupArgParser {
+    override fun parseArguments(args: Array<out String>, meta: ItemMeta): Predicate<ItemStack>? {
+        val arg = args.firstOrNull { it.startsWith("pet-xp:") } ?: return null
+        val xp = arg.substringAfter(":").toDoubleOrNull() ?: return null
+
+        meta.persistentDataContainer.set(petEggXpKey, PersistentDataType.DOUBLE, xp)
+
+        val pdc = meta.persistentDataContainer
+        val petId = pdc.get(petEggKey, PersistentDataType.STRING)
+        val pet = petId?.let { Pets.getByID(it) }
+        if (pet != null) {
+            val level = pdc.get(petEggLevelKey, PersistentDataType.INTEGER) ?: 1
+            pet.makeSpawnEgg(level, xp)?.itemMeta?.also { eggMeta ->
+                meta.displayName(eggMeta.displayName())
+                meta.lore(eggMeta.lore())
+            }
+        }
+
+        return Predicate { it.petEggXp == xp }
+    }
+
+    override fun serializeBack(meta: ItemMeta): String? {
+        val xp = meta.persistentDataContainer.get(petEggXpKey, PersistentDataType.DOUBLE) ?: return null
+        return "pet-xp:$xp"
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pet.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pet.kt
@@ -9,6 +9,8 @@ import com.willfp.eco.core.fast.fast
 import com.willfp.eco.core.items.CustomItem
 import com.willfp.eco.core.items.Items
 import com.willfp.eco.core.items.builder.ItemStackBuilder
+import com.willfp.eco.core.price.ConfiguredPrice
+import com.willfp.eco.core.price.Prices
 import com.willfp.eco.core.placeholder.PlayerPlaceholder
 import com.willfp.eco.core.placeholder.PlayerStaticPlaceholder
 import com.willfp.eco.core.placeholder.PlayerlessPlaceholder
@@ -28,6 +30,7 @@ import com.willfp.ecopets.api.event.PlayerPetExpGainEvent
 import com.willfp.ecopets.api.event.PlayerPetLevelUpEvent
 import com.willfp.ecopets.pets.entity.PetEntity
 import com.willfp.ecopets.plugin
+import com.willfp.ecopets.price.PriceFactoryPetLevel
 import com.willfp.ecopets.util.LevelInjectable
 import com.willfp.libreforge.SimpleProvidedHolder
 import com.willfp.libreforge.ViolationContext
@@ -66,45 +69,52 @@ class Pet(
         plugin.namespacedKeyFactory.create("${id}_xp"), PersistentDataKeyType.DOUBLE, 0.0
     )
 
-    private val spawnEggBacker: ItemStack? = run {
-        val enabled = config.getBool("spawn-egg.enabled")
-        if (!enabled) {
-            return@run null
-        }
-
+    // Resolved and cloned at init time (before custom item registration) so that
+    // subsequent makeSpawnEgg calls always start from the clean raw item and never
+    // accidentally pick up the registered custom item's already-baked lore.
+    private val eggBaseItem: ItemStack? = run {
+        if (!config.getBool("spawn-egg.enabled")) return@run null
         val lookup = Items.lookup(config.getString("spawn-egg.item"))
+        if (lookup is EmptyTestableItem) null else lookup.item.clone()
+    }
 
-        if (lookup is EmptyTestableItem) {
-            return@run null
+    private val eggBaseName = config.getFormattedStringOrNull("spawn-egg.name")
+    private val eggBaseLore = config.getFormattedStrings("spawn-egg.lore")
+
+    private fun formatEggText(text: String, level: Int, xp: Double): String {
+        var result = text
+            .replace("%pet%", this.name)
+            .replace("%description%", this.description)
+            .replace("%current_xp%", xp.toNiceString())
+            .replace("%level%", level.toString())
+            .replace("%level_numeral%", level.toNumeral())
+        result = EGG_LEVEL_REGEX.replace(result) { match ->
+            val offset = match.groupValues[1].toIntOrNull() ?: return@replace match.value
+            val isNumeral = match.groupValues[2].isNotEmpty()
+            val newLevel = level + offset
+            if (isNumeral) newLevel.toNumeral() else newLevel.toString()
         }
+        return result
+    }
 
-        val name = config.getFormattedStringOrNull("spawn-egg.name")
-
-        val item = ItemStackBuilder(lookup)
-            .addLoreLines(config.getFormattedStrings("spawn-egg.lore"))
+    fun makeSpawnEgg(level: Int = 1, xp: Double = 0.0): ItemStack? {
+        val base = eggBaseItem?.clone() ?: return null
+        val item = ItemStackBuilder(base)
+            .addLoreLines(eggBaseLore.map { formatEggText(it, level, xp) })
             .apply {
-                if (name != null) {
-                    setDisplayName(name)
+                if (eggBaseName != null) {
+                    setDisplayName(formatEggText(eggBaseName, level, xp))
                 }
             }
-            .build().apply { petEgg = this@Pet }
-
-        val key = plugin.namespacedKeyFactory.create("${this.id}_spawn_egg")
-
-        Items.registerCustomItem(
-            key,
-            CustomItem(
-                key,
-                { it.petEgg == this },
-                item
-            )
-        )
-
-        item
+            .build()
+        item.petEgg = this
+        item.petEggLevel = level
+        item.petEggXp = xp
+        return item
     }
 
     val spawnEgg: ItemStack?
-        get() = this.spawnEggBacker?.clone()
+        get() = makeSpawnEgg(1, 0.0)
 
     val recipe: CraftingRecipe? = spawnEgg
         ?.takeIf { config.getBool("spawn-egg.craftable") }
@@ -129,6 +139,13 @@ class Pet(
     private val levelXpRequirements = listOf(0) + config.getInts("level-xp-requirements")
 
     val maxLevel = config.getIntOrNull("max-level") ?: levelXpRequirements.size
+
+    val withdrawable = config.getBool("spawn-egg.withdrawable")
+
+    val withdrawPrice: ConfiguredPrice by lazy {
+        ConfiguredPrice.create(config.getSubsection("spawn-egg.withdraw-price"))
+            ?: ConfiguredPrice.FREE
+    }
 
     val levelGUI = PetLevelGUI(this)
 
@@ -160,6 +177,8 @@ class Pet(
             }
         }
 
+    internal val priceFactory = PriceFactoryPetLevel(this)
+
     private val petXpGains = config.getSubsections("xp-gain-methods").mapNotNull {
         Counters.compile(it, ViolationContext(plugin, "Pet $id"))
     }
@@ -190,6 +209,9 @@ class Pet(
             },
             PlayerStaticPlaceholder("level_numeral") {
                 it.getPetLevel(this).toNumeral()
+            },
+            PlayerStaticPlaceholder("withdraw_price") {
+                this.withdrawPrice.getDisplay(it)
             }
         )
 
@@ -298,6 +320,21 @@ class Pet(
         ) {
             canActivate(it).toString()
         }.register()
+
+        PlayerPlaceholder(
+            plugin,
+            "${id}_withdraw_price"
+        ) {
+            this.withdrawPrice.getDisplay(it)
+        }.register()
+
+        makeSpawnEgg(1, 0.0)?.let { representative ->
+            val key = plugin.namespacedKeyFactory.create("${this.id}_spawn_egg")
+            Items.registerCustomItem(
+                key,
+                CustomItem(key, { it.petEgg == this }, representative)
+            )
+        }
     }
 
     val levelUpEffects = Effects.compileChain(
@@ -430,10 +467,12 @@ class Pet(
 
     override fun onRegister() {
         petXpGains.forEach { it.bind(PetXPAccumulator(this)) }
+        Prices.registerPriceFactory(priceFactory)
     }
 
     override fun onRemove() {
         petXpGains.forEach { it.unbind() }
+        Prices.unregisterPriceFactory(priceFactory)
     }
 
     fun getIcon(player: Player): ItemStack {
@@ -537,6 +576,8 @@ private fun Collection<LevelPlaceholder>.format(string: String, level: Int): Str
     return process
 }
 
+private val EGG_LEVEL_REGEX = Regex("%level_([+-]?\\d+)(_numeral)?%")
+
 private val activePetKey: PersistentDataKey<String> = PersistentDataKey(
     plugin.namespacedKeyFactory.create("active_pet"),
     PersistentDataKeyType.STRING,
@@ -549,13 +590,27 @@ private val shouldHidePetKey: PersistentDataKey<Boolean> = PersistentDataKey(
     false
 )
 
-private val petEggKey = plugin.namespacedKeyFactory.create("pet_egg")
+internal val petEggKey = plugin.namespacedKeyFactory.create("pet_egg")
+internal val petEggLevelKey = plugin.namespacedKeyFactory.create("pet_egg_level")
+internal val petEggXpKey = plugin.namespacedKeyFactory.create("pet_egg_xp")
 
 var ItemStack.petEgg: Pet?
     get() = Pets.getByID(this.fast().persistentDataContainer.get(petEggKey, PersistentDataType.STRING) ?: "")
     set(value) {
         value ?: return
         this.fast().persistentDataContainer.set(petEggKey, PersistentDataType.STRING, value.id)
+    }
+
+var ItemStack.petEggLevel: Int
+    get() = this.fast().persistentDataContainer.get(petEggLevelKey, PersistentDataType.INTEGER) ?: 1
+    set(value) {
+        this.fast().persistentDataContainer.set(petEggLevelKey, PersistentDataType.INTEGER, value)
+    }
+
+var ItemStack.petEggXp: Double
+    get() = this.fast().persistentDataContainer.get(petEggXpKey, PersistentDataType.DOUBLE) ?: 0.0
+    set(value) {
+        this.fast().persistentDataContainer.set(petEggXpKey, PersistentDataType.DOUBLE, value)
     }
 
 var OfflinePlayer.activePet: Pet?

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetWithdrawal.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetWithdrawal.kt
@@ -1,0 +1,70 @@
+package com.willfp.ecopets.pets
+
+import com.willfp.eco.core.drops.DropQueue
+import com.willfp.eco.util.StringUtils
+import com.willfp.ecopets.plugin
+import org.bukkit.entity.Player
+
+enum class WithdrawResult {
+    OK, NO_ACTIVE, NOT_WITHDRAWABLE, CANNOT_AFFORD
+}
+
+fun canWithdraw(player: Player, pet: Pet?): WithdrawResult {
+    if (pet == null) return WithdrawResult.NO_ACTIVE
+    if (!pet.withdrawable) return WithdrawResult.NOT_WITHDRAWABLE
+    if (!pet.withdrawPrice.canAfford(player)) return WithdrawResult.CANNOT_AFFORD
+    return WithdrawResult.OK
+}
+
+/** Sends the appropriate lang message for a non-OK result. */
+fun WithdrawResult.notifyFail(player: Player, pet: Pet?) {
+    when (this) {
+        WithdrawResult.NO_ACTIVE ->
+            player.sendMessage(plugin.langYml.getMessage("no-active-pet-to-withdraw"))
+        WithdrawResult.NOT_WITHDRAWABLE ->
+            player.sendMessage(plugin.langYml.getMessage("pet-not-withdrawable"))
+        WithdrawResult.CANNOT_AFFORD ->
+            player.sendMessage(
+                plugin.langYml.getMessage("cannot-afford-withdraw", StringUtils.FormatOption.WITHOUT_PLACEHOLDERS)
+                    .replace("%price%", pet?.withdrawPrice?.getDisplay(player) ?: "")
+            )
+        WithdrawResult.OK -> {}
+    }
+}
+
+/** Performs the withdrawal. Returns true on success. Re-validates before acting. */
+fun withdrawPet(player: Player, pet: Pet): Boolean {
+    val result = canWithdraw(player, pet)
+    if (result != WithdrawResult.OK) {
+        result.notifyFail(player, pet)
+        return false
+    }
+    if (player.activePet != pet) {
+        player.sendMessage(plugin.langYml.getMessage("no-active-pet-to-withdraw"))
+        return false
+    }
+
+    pet.withdrawPrice.pay(player)
+
+    val level = player.getPetLevel(pet)
+    val xp = player.getPetXP(pet)
+    val egg = pet.makeSpawnEgg(level, xp) ?: run {
+        player.sendMessage(plugin.langYml.getMessage("pet-not-withdrawable"))
+        return false
+    }
+
+    DropQueue(player)
+        .addItem(egg)
+        .forceTelekinesis()
+        .push()
+
+    player.setPetLevel(pet, 0)
+    player.setPetXP(pet, 0.0)
+    player.activePet = null
+
+    player.sendMessage(
+        plugin.langYml.getMessage("pet-withdrawn", StringUtils.FormatOption.WITHOUT_PLACEHOLDERS)
+            .replace("%pet%", pet.name)
+    )
+    return true
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pets.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pets.kt
@@ -2,6 +2,7 @@ package com.willfp.ecopets.pets
 
 import com.google.common.collect.ImmutableList
 import com.willfp.eco.core.config.interfaces.Config
+import com.willfp.eco.core.price.Prices
 import com.willfp.eco.core.registry.Registry
 import com.willfp.libreforge.loader.LibreforgePlugin
 import com.willfp.libreforge.loader.configs.ConfigCategory
@@ -37,6 +38,9 @@ object Pets : ConfigCategory("pet", "pets") {
     }
 
     override fun clear(plugin: LibreforgePlugin) {
+        for (pet in registry.values()) {
+            Prices.unregisterPriceFactory(pet.priceFactory)
+        }
         registry.clear()
     }
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetsGUI.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetsGUI.kt
@@ -177,6 +177,38 @@ object PetsGUI {
                 }
             )
 
+            val withdrawEnabled = plugin.configYml.getBoolOrNull("gui.withdraw-pet.enabled") ?: true
+            if (withdrawEnabled) {
+                setSlot(
+                    plugin.configYml.getInt("gui.withdraw-pet.location.row"),
+                    plugin.configYml.getInt("gui.withdraw-pet.location.column"),
+                    slot(
+                        { player: Player, _: Menu ->
+                            ItemStackBuilder(Items.lookup(plugin.configYml.getString("gui.withdraw-pet.item")))
+                                .setDisplayName(plugin.configYml.getFormattedString("gui.withdraw-pet.name"))
+                                .addLoreLines {
+                                    val pet = player.activePet
+                                    plugin.configYml.getStrings("gui.withdraw-pet.lore").map { line ->
+                                        line.replace("%withdraw_price%", pet?.withdrawPrice?.getDisplay(player) ?: "")
+                                    }
+                                }
+                                .build()
+                        }
+                    ) {
+                        onLeftClick { event, _ ->
+                            val player = event.whoClicked as Player
+                            val pet = player.activePet
+                            val result = canWithdraw(player, pet)
+                            if (result != WithdrawResult.OK || pet == null) {
+                                result.notifyFail(player, pet)
+                                return@onLeftClick
+                            }
+                            WithdrawConfirmGUI.open(player, pet)
+                        }
+                    }
+                )
+            }
+
             setSlot(
                 plugin.configYml.getInt("gui.toggle.location.row"),
                 plugin.configYml.getInt("gui.toggle.location.column"),

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/SpawnEggHandler.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/SpawnEggHandler.kt
@@ -26,20 +26,29 @@ object SpawnEggHandler : Listener {
         event.isCancelled = true
         event.setUseItemInHand(Event.Result.DENY)
 
-        if (player.hasPet(pet)) {
-            player.sendMessage(plugin.langYml.getMessage("cannot-spawn-pet"))
-            return
+        val eggLevel = item.petEggLevel
+        val eggXp = item.petEggXp
+        val ownedLevel = player.getPetLevel(pet)
+
+        if (ownedLevel > 0) {
+            val policy = plugin.configYml.getString("pet-egg.redeem-conflict").lowercase()
+            if (policy == "reject" || eggLevel <= ownedLevel) {
+                player.sendMessage(
+                    if (policy == "reject") plugin.langYml.getMessage("cannot-spawn-pet")
+                    else plugin.langYml.getMessage("egg-lower-level")
+                )
+                return
+            }
         }
 
         if (event.hand == EquipmentSlot.HAND) {
-            val hand = event.player.inventory.itemInMainHand
-            hand.amount -= 1
+            event.player.inventory.itemInMainHand.amount -= 1
         } else {
-            val hand = event.player.inventory.itemInOffHand
-            hand.amount -= 1
+            event.player.inventory.itemInOffHand.amount -= 1
         }
 
-        player.setPetLevel(pet, 1)
+        player.setPetLevel(pet, maxOf(eggLevel, 1))
+        player.setPetXP(pet, eggXp)
         player.sendMessage(
             plugin.langYml.getMessage("pet-spawned", StringUtils.FormatOption.WITHOUT_PLACEHOLDERS)
                 .replace("%pet%", pet.name)

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/WithdrawConfirmGUI.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/WithdrawConfirmGUI.kt
@@ -1,0 +1,76 @@
+package com.willfp.ecopets.pets
+
+import com.willfp.eco.core.gui.menu
+import com.willfp.eco.core.gui.slot
+import com.willfp.eco.core.gui.slot.ConfigSlot
+import com.willfp.eco.core.gui.slot.FillerMask
+import com.willfp.eco.core.gui.slot.MaskItems
+import com.willfp.eco.core.items.Items
+import com.willfp.eco.core.items.builder.ItemStackBuilder
+import com.willfp.eco.core.sound.PlayableSound
+import com.willfp.ecopets.plugin
+import org.bukkit.entity.Player
+
+object WithdrawConfirmGUI {
+    fun open(player: Player, pet: Pet) {
+        val cfg = plugin.configYml.getSubsection("gui.withdraw-pet.confirm")
+        val confirmCfg = cfg.getSubsection("confirm")
+        val cancelCfg = cfg.getSubsection("cancel")
+
+        val gui = menu(cfg.getInt("rows")) {
+            title = cfg.getFormattedString("title")
+
+            setMask(
+                FillerMask(
+                    MaskItems.fromItemNames(cfg.getStrings("mask.materials")),
+                    *cfg.getStrings("mask.pattern").toTypedArray()
+                )
+            )
+
+            setSlot(
+                confirmCfg.getInt("row"),
+                confirmCfg.getInt("column"),
+                slot(
+                    ItemStackBuilder(Items.lookup(confirmCfg.getString("item")))
+                        .setDisplayName(confirmCfg.getFormattedString("name"))
+                        .addLoreLines(confirmCfg.getFormattedStrings("lore"))
+                        .build()
+                ) {
+                    onLeftClick { event, _ ->
+                        val clicker = event.whoClicked as Player
+                        PlayableSound.create(confirmCfg.getSubsection("sound"))?.playTo(clicker)
+                        clicker.closeInventory()
+                        withdrawPet(clicker, pet)
+                    }
+                }
+            )
+
+            setSlot(
+                cancelCfg.getInt("row"),
+                cancelCfg.getInt("column"),
+                slot(
+                    ItemStackBuilder(Items.lookup(cancelCfg.getString("item")))
+                        .setDisplayName(cancelCfg.getFormattedString("name"))
+                        .addLoreLines(cancelCfg.getFormattedStrings("lore"))
+                        .build()
+                ) {
+                    onLeftClick { event, _ ->
+                        val clicker = event.whoClicked as Player
+                        PlayableSound.create(cancelCfg.getSubsection("sound"))?.playTo(clicker)
+                        PetsGUI.open(clicker)
+                    }
+                }
+            )
+
+            for (config in cfg.getSubsections("custom-slots")) {
+                setSlot(
+                    config.getInt("row"),
+                    config.getInt("column"),
+                    ConfigSlot(config)
+                )
+            }
+        }
+
+        gui.open(player)
+    }
+}

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/price/PriceFactoryPetLevel.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/price/PriceFactoryPetLevel.kt
@@ -1,0 +1,58 @@
+package com.willfp.ecopets.price
+
+import com.willfp.eco.core.placeholder.context.PlaceholderContext
+import com.willfp.eco.core.placeholder.context.PlaceholderContextSupplier
+import com.willfp.eco.core.price.Price
+import com.willfp.eco.core.price.PriceFactory
+import com.willfp.ecopets.pets.Pet
+import com.willfp.ecopets.pets.getPetLevel
+import com.willfp.ecopets.pets.setPetLevel
+import org.bukkit.entity.Player
+import java.util.UUID
+import kotlin.math.max
+
+class PriceFactoryPetLevel(
+    private val pet: Pet
+) : PriceFactory {
+    override fun getNames() = listOf("${pet.id}_pet_level")
+
+    override fun create(baseContext: PlaceholderContext, function: PlaceholderContextSupplier<Double>): Price {
+        return PricePetLevel(baseContext) { function.get(it) }
+    }
+
+    private inner class PricePetLevel(
+        private val baseContext: PlaceholderContext,
+        private val function: (PlaceholderContext) -> Double
+    ) : Price {
+        private val multipliers = mutableMapOf<UUID, Double>()
+
+        override fun canAfford(player: Player, multiplier: Double): Boolean {
+            return player.getPetLevel(pet) >= getValue(player, multiplier)
+        }
+
+        override fun pay(player: Player, multiplier: Double) {
+            val newLevel = max(0, player.getPetLevel(pet) - getValue(player, multiplier).toInt())
+            player.setPetLevel(pet, newLevel)
+        }
+
+        override fun giveTo(player: Player, multiplier: Double) {
+            player.setPetLevel(pet, player.getPetLevel(pet) + getValue(player, multiplier).toInt())
+        }
+
+        override fun getValue(player: Player, multiplier: Double): Double {
+            return function(baseContext.copyWithPlayer(player)) * getMultiplier(player) * multiplier
+        }
+
+        override fun getMultiplier(player: Player): Double {
+            return multipliers[player.uniqueId] ?: 1.0
+        }
+
+        override fun setMultiplier(player: Player, multiplier: Double) {
+            multipliers[player.uniqueId] = multiplier
+        }
+
+        override fun getIdentifier(): String {
+            return "ecopets:${pet.id}_pet_level"
+        }
+    }
+}

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -10,6 +10,12 @@ use-local-storage: false
 
 discover-recipes: true
 
+# How redeeming a pet egg behaves when the player ALREADY owns that pet:
+# keep-higher - overwrite only if the egg's level is higher than the owned level, else reject
+# reject - never redeem if the pet is already owned (player must withdraw theirs first)
+pet-egg:
+  redeem-conflict: keep-higher
+
 # If a pet should be automatically deactivated when its activate-conditions are no longer met
 auto-deactivate-on-condition-fail: true
 
@@ -159,6 +165,60 @@ gui:
     location:
       row: 6
       column: 2
+
+  withdraw-pet:
+    enabled: true
+    item: player_head texture:eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYmFkYzA0OGE3Y2U3OGY3ZGFkNzJhMDdkYTI3ZDg1YzA5MTY4ODFlNTUyMmVlZWQxZTNkYWYyMTdhMzhjMWEifX19
+    name: "&cWithdraw Pet"
+    lore:
+      - "&7Withdraw your active pet into an egg"
+      - "&7you can trade or give to others."
+      - ""
+      - "&cYou will lose all progress on this pet!"
+      - "&7Cost: &e%withdraw_price%"
+    location:
+      row: 6
+      column: 3
+    confirm:
+      rows: 3
+      title: "&cConfirm Withdrawal"
+
+      mask:
+        materials:
+          - black_stained_glass_pane
+        pattern:
+          - "111111111"
+          - "100000001"
+          - "111111111"
+
+      confirm:
+        item: lime_stained_glass_pane
+        name: "&aConfirm Withdrawal"
+        lore:
+          - "&7Withdraw your active pet into an egg."
+        row: 2
+        column: 3
+        sound:
+          enabled: true
+          sound: ui_button_click
+          pitch: 1
+          volume: 1
+          category: UI
+      cancel:
+        item: red_stained_glass_pane
+        name: "&cCancel"
+        lore: [ ]
+        row: 2
+        column: 7
+        sound:
+          enabled: true
+          sound: ui_button_click
+          pitch: 1
+          volume: 1
+          category: UI
+
+      # Custom GUI slots; see here for a how-to: https://plugins.auxilor.io/all-plugins/custom-gui-slots
+      custom-slots: [ ]
 
   toggle:
     hide-pet:

--- a/eco-core/core-plugin/src/main/resources/lang.yml
+++ b/eco-core/core-plugin/src/main/resources/lang.yml
@@ -20,6 +20,7 @@ messages:
   took-pet: "&fSuccessfully took %player%&f's %pet%&f pet!"
   gave-pet-egg: "&fSuccessfully gave %player%&f the %pet%&f pet egg!"
   cannot-spawn-pet: "&cYou already have this pet unlocked!"
+  egg-lower-level: "&cThis egg's pet level is not higher than your current one!"
   pet-spawned: "&fYou've spawned your %pet%&f pet! Visit &a/pets&f to activate it!"
   invalid-amount: "&cInvalid amount!"
   pet-already-active: "&cYou already have this pet active!"
@@ -31,6 +32,10 @@ messages:
   cancelled-adoption: "&cThat player is not allowed to adopt that pet!"
   cancelled-swap: "&cYou are not allowed to swap to that pet!"
   cancelled-swap-other: "&cThat player is not allowed to swap to that pet!"
+  no-active-pet-to-withdraw: "&cYou have no active pet to withdraw!"
+  pet-not-withdrawable: "&cThis pet cannot be withdrawn!"
+  cannot-afford-withdraw: "&cYou cannot afford to withdraw this pet! Cost: &e%price%"
+  pet-withdrawn: "&fYou withdrew your %pet%&f pet into an egg!"
 
 menu:
   title: "Pets (%page%/%max_page%)"

--- a/eco-core/core-plugin/src/main/resources/pets/_example.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/_example.yml
@@ -124,3 +124,15 @@ spawn-egg:
   recipe-permission: ecopets.craft.tiger # (Optional) The permission required to see the crafting recipe
   shapeless: false # (Optional) Whether the crafting recipe is shapeless, defaults to false
   recipe: [ ]
+
+  # Whether players can withdraw this pet into a tradeable egg via the GUI button.
+  withdrawable: true
+
+  # Cost to withdraw. Any registered currency (coins, points, eco-bits, items...),
+  # or this pet's level currency: type: tiger_pet_level (charges pet levels).
+  # See https://plugins.auxilor.io/all-plugins/prices
+  withdraw-price:
+    enabled: false
+    type: blaze_pet_level
+    value: 10
+    display: "%value% pet levels"

--- a/eco-core/core-plugin/src/main/resources/pets/blaze.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/blaze.yml
@@ -92,3 +92,4 @@ spawn-egg:
   craftable: false
   recipe: []
   recipe-permission: ecopets.craft.blaze
+  withdrawable: true

--- a/eco-core/core-plugin/src/main/resources/pets/mancubus.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/mancubus.yml
@@ -101,3 +101,4 @@ spawn-egg:
   craftable: false
   recipe: [ ]
   recipe-permission: ecopets.craft.mancubus
+  withdrawable: true

--- a/eco-core/core-plugin/src/main/resources/pets/ravager.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/ravager.yml
@@ -96,3 +96,4 @@ spawn-egg:
   craftable: false
   recipe: [ ]
   recipe-permission: ecopets.craft.ravager
+  withdrawable: true

--- a/eco-core/core-plugin/src/main/resources/pets/sea_serpent.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/sea_serpent.yml
@@ -119,3 +119,4 @@ spawn-egg:
   craftable: false
   recipe: [ ]
   recipe-permission: ecopets.craft.sea_serpent
+  withdrawable: true

--- a/eco-core/core-plugin/src/main/resources/pets/skeleton.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/skeleton.yml
@@ -101,3 +101,4 @@ spawn-egg:
   craftable: false
   recipe: [ ]
   recipe-permission: ecopets.craft.skeleton
+  withdrawable: true

--- a/eco-core/core-plugin/src/main/resources/pets/tiger.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/tiger.yml
@@ -102,3 +102,4 @@ spawn-egg:
   craftable: false
   recipe: [ ]
   recipe-permission: ecopets.craft.tiger
+  withdrawable: true

--- a/eco-core/core-plugin/src/main/resources/pets/vampire.yml
+++ b/eco-core/core-plugin/src/main/resources/pets/vampire.yml
@@ -159,3 +159,4 @@ spawn-egg:
   craftable: false
   recipe: [ ]
   recipe-permission: ecopets.craft.vampire
+  withdrawable: true


### PR DESCRIPTION
This PR adds the ability for players to withdraw their currently active pet back into a pet spawn egg, which can be traded/gifted.

Upon withdrawal, it resets the player's pet level/xp to ensure fairness.

Added new arg parsers and pet-level to prices