### PR TITLE
feat: improve pet entity display offsets

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetDisplay.kt
@@ -95,14 +95,26 @@ object PetDisplay : Listener {
     }
 
     private fun getLocation(player: Player, d: Double): Location {
-        val direction = player.eyeLocation.direction.clone().normalize()
-
         val locationXOffset = plugin.configYml.getDoubleOrNull("pet-entity.location_x_offset") ?: 0.75
         val locationZOffset = plugin.configYml.getDoubleOrNull("pet-entity.location_z_offset") ?: 0.75
-        val offset = direction.clone().apply {
-            x *= -locationXOffset
-            z *= -locationZOffset
+
+        // Calculate horizontal forward direction from player yaw, ignoring vertical pitch
+        val forward = player.location.direction.clone()
+        forward.y = 0.0
+
+        if (forward.lengthSquared() > 0.0) {
+            forward.normalize()
         }
+
+        // Calculate right-side vector from forward direction
+        val right = forward.clone().rotateAroundY(-Math.PI / 2)
+
+        // Apply stable local-space offset:
+        // X = left/right offset
+        // Z = forward/backward offset
+        val offset = forward.clone()
+            .multiply(-locationZOffset)
+            .add(right.multiply(locationXOffset))
 
         val uuid = player.uniqueId
         val currentTime = System.currentTimeMillis()
@@ -132,11 +144,6 @@ object PetDisplay : Listener {
 
         offset.y = smoothedYOffset
 
-        // Smooth X/Z bias
-        if (abs(offset.x) < 0.3) offset.x *= 1.5
-        if (abs(offset.z) < 0.3) offset.z *= 1.5
-
-        offset.rotateAroundY(Math.PI / 12)
         cleanupOldEntries(currentTime)
 
         // Use base location, not eyeLocation, for static anchoring

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -292,7 +292,7 @@ pet-entity:
   enabled: true # If you disable this, there will be no floating pets
   show-hologram: true # If the pet's name should be shown above the pet
   name: "%player%&f's %pet%&f (Lvl. %level%)"
-  location-x-offset: 0.75 # How far the pet should be from the player on the X axis (Default: 0.75)
+  location_x_offset: 0.75 # How far the pet should be from the player on the X axis (Default: 0.75)
   location-y-offset: 0.0 # How far the pet should be from the player on the Y axis (Default: 0.0)
   location_z_offset: 0.75 # How far the pet should be from the player on the Z axis (Default: 0.75)
   bobbing: true # If the pet should bob up and down


### PR DESCRIPTION
Switch pet positioning to use a horizontal local-space offset based on player yaw, avoiding pitch-based drift and the extra X/Z bias rotation. Also rename the X offset config key to `location_x_offset` to match the one used in code.