### PR TITLE
feat: Apply level placeholders to pet egg

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pet.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/Pet.kt
@@ -69,6 +69,18 @@ class Pet(
         plugin.namespacedKeyFactory.create("${id}_xp"), PersistentDataKeyType.DOUBLE, 0.0
     )
 
+    private val levelPlaceholders = config.getSubsections("level-placeholders")
+        .map { sub ->
+            LevelPlaceholder(
+                sub.getString("id")
+            ) {
+                evaluateExpression(
+                    sub.getString("value")
+                        .replace("%level%", it.toString())
+                )
+            }
+        }
+
     // Resolved and cloned at init time (before custom item registration) so that
     // subsequent makeSpawnEgg calls always start from the clean raw item and never
     // accidentally pick up the registered custom item's already-baked lore.
@@ -94,7 +106,7 @@ class Pet(
             val newLevel = level + offset
             if (isNumeral) newLevel.toNumeral() else newLevel.toString()
         }
-        return result
+        return levelPlaceholders.format(result, level)
     }
 
     fun makeSpawnEgg(level: Int = 1, xp: Double = 0.0): ItemStack? {
@@ -164,18 +176,6 @@ class Pet(
     private val rewardsDescription = EcoCache.builder<Int, List<String>>().build()
 
     private val levelUpMessages = EcoCache.builder<Int, List<String>>().build()
-
-    private val levelPlaceholders = config.getSubsections("level-placeholders")
-        .map { sub ->
-            LevelPlaceholder(
-                sub.getString("id")
-            ) {
-                evaluateExpression(
-                    sub.getString("value")
-                        .replace("%level%", it.toString())
-                )
-            }
-        }
 
     internal val priceFactory = PriceFactoryPetLevel(this)
 

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetsGUI.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecopets/pets/PetsGUI.kt
@@ -179,6 +179,7 @@ object PetsGUI {
 
             val withdrawEnabled = plugin.configYml.getBoolOrNull("gui.withdraw-pet.enabled") ?: true
             if (withdrawEnabled) {
+                val confirmEnabled = plugin.configYml.getBoolOrNull("gui.withdraw-pet.confirm.enabled") ?: true
                 setSlot(
                     plugin.configYml.getInt("gui.withdraw-pet.location.row"),
                     plugin.configYml.getInt("gui.withdraw-pet.location.column"),
@@ -203,7 +204,12 @@ object PetsGUI {
                                 result.notifyFail(player, pet)
                                 return@onLeftClick
                             }
-                            WithdrawConfirmGUI.open(player, pet)
+                            if (confirmEnabled) {
+                                WithdrawConfirmGUI.open(player, pet)
+                            } else {
+                                player.closeInventory()
+                                withdrawPet(player, pet)
+                            }
                         }
                     }
                 )

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -180,6 +180,7 @@ gui:
       row: 6
       column: 3
     confirm:
+      enabled: true
       rows: 3
       title: "&cConfirm Withdrawal"
 


### PR DESCRIPTION
- Add level placeholders support inside pet egg (for the withdraw)
- Withdraw confirm GUI can now be disabled